### PR TITLE
run processes so we can get the output

### DIFF
--- a/tests/Humbug/Test/Adapter/PhpunitTest.php
+++ b/tests/Humbug/Test/Adapter/PhpunitTest.php
@@ -50,14 +50,18 @@ class PhpunitTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $adapter = new Phpunit;
-        $result = $adapter->runTests(
+        $process = $adapter->runTests(
             $container,
             true, 
             true
         );
+        $process->run();
+
+        $result = $process->getOutput();
+
         $this->assertStringStartsWith(
             \PHPUnit_Runner_Version::getVersionString(),
-            $result['output']['stdout']
+            $result
         );
     }
 
@@ -77,14 +81,18 @@ class PhpunitTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $adapter = new Phpunit;
-        $result = $adapter->runTests(
+        $process = $adapter->runTests(
             $container,
             true, 
             true
         );
+        $process->run();
+
+        $result = $process->getOutput();
+
         $this->assertStringStartsWith(
             \PHPUnit_Runner_Version::getVersionString(),
-            $result['output']['stdout']
+            $result
         );
     }
 
@@ -103,12 +111,16 @@ class PhpunitTest extends \PHPUnit_Framework_TestCase
         ]);
         
         $adapter = new Phpunit;
-        $result = $adapter->runTests(
+        $process = $adapter->runTests(
             $container,
             true, 
             true
         );
-        $this->assertTrue($adapter->processOutput($result['output']['stdout']));
+        $process->run();
+
+        $result = $process->getOutput();
+
+        $this->assertTrue($adapter->processOutput($result));
     }
 
     public function testAdapterDetectsTestsFailingFromTestFail()
@@ -127,12 +139,16 @@ class PhpunitTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $adapter = new Phpunit;
-        $result = $adapter->runTests(
+        $process = $adapter->runTests(
             $container,
             true, 
             true
         );
-        $this->assertFalse($adapter->processOutput($result['output']['stdout']));
+        $process->run();
+
+        $result = $process->getOutput();
+
+        $this->assertFalse($adapter->processOutput($result));
     }
 
     public function testAdapterDetectsTestsFailingFromException()
@@ -150,12 +166,16 @@ class PhpunitTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $adapter = new Phpunit;
-        $result = $adapter->runTests(
+        $process = $adapter->runTests(
             $container,
             true, 
             true
         );
-        $this->assertFalse($adapter->processOutput($result['output']['stdout']));
+        $process->run();
+
+        $result = $process->getOutput();
+
+        $this->assertFalse($adapter->processOutput($result));
     }
 
     public function testAdapterDetectsTestsFailingFromError()
@@ -173,12 +193,16 @@ class PhpunitTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $adapter = new Phpunit;
-        $result = $adapter->runTests(
+        $process = $adapter->runTests(
             $container,
             true, 
             true
         );
-        $this->assertFalse($adapter->processOutput($result['output']['stdout']));
+        $process->run();
+
+        $result = $process->getOutput();
+
+        $this->assertFalse($adapter->processOutput($result));
     }
     
     public function testAdapterOutputProcessingDetectsFailOverMultipleLinesWithNoDepOnFinalStatusReport()


### PR DESCRIPTION
Running Humbug's unit tests would fail with

    PHP Fatal error:  Cannot use object of type Symfony\Component\Process\PhpProcess as array in /home/vagrant/humbug/tests/Humbug/Test/Adapter/PhpunitTest.php on line 60

so I guess explicitly calling the `process->run()` is needed in tests. Plus the Phpunit adapter returns a process, does not call it https://github.com/padraic/humbug/blob/master/src/Humbug/Adapter/Phpunit.php#L126