### PR TITLE
check if suite is a DOMElement

### DIFF
--- a/src/Humbug/Adapter/Phpunit.php
+++ b/src/Humbug/Adapter/Phpunit.php
@@ -271,31 +271,33 @@ class Phpunit extends AdapterAbstract
             
             // TODO: Handle >1 test suites
             $suite1 = $xpath->query('/phpunit/testsuites/testsuite')->item(0);
-            foreach ($suite1->childNodes as $child) {
-                if ($child instanceof \DOMElement && $child->tagName !== 'exclude') {
-                    $suite1->removeChild($child);
+            if (is_a($suite1, 'DOMElement')) {
+                foreach ($suite1->childNodes as $child) {
+                    if ($child instanceof \DOMElement && $child->tagName !== 'exclude') {
+                        $suite1->removeChild($child);
+                    }
                 }
-            }
 
-            /**
-             * Add test files explicitly in order given
-             */
-            $files = [];
-            foreach ($cases as $case) {
-                $files[] = $case['file'];
-                $file = $dom->createElement('file', $case['file']);
-                $suite1->appendChild($file);
-            }
-            /**
-             * JUnit logging excludes some immeasurable tests so we'll add those back.
-             */
-            if ($addMissingTests) {
-                $finder = new Finder;
-                $finder->name('*Test.php');
-                foreach ($finder->in($container->getBaseDirectory())->exclude('vendor') as $file) {
-                    if (!in_array($file->getRealpath(), $files)) {
-                        $file = $dom->createElement('file', $file->getRealpath());
-                        $suite1->appendChild($file);
+                /**
+                 * Add test files explicitly in order given
+                 */
+                $files = [];
+                foreach ($cases as $case) {
+                    $files[] = $case['file'];
+                    $file = $dom->createElement('file', $case['file']);
+                    $suite1->appendChild($file);
+                }
+                /**
+                 * JUnit logging excludes some immeasurable tests so we'll add those back.
+                 */
+                if ($addMissingTests) {
+                    $finder = new Finder;
+                    $finder->name('*Test.php');
+                    foreach ($finder->in($container->getBaseDirectory())->exclude('vendor') as $file) {
+                        if (!in_array($file->getRealpath(), $files)) {
+                            $file = $dom->createElement('file', $file->getRealpath());
+                            $suite1->appendChild($file);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If the phpunit.xml file is incorrectly/differently configured, `$suite1` is  going to be null.

If there is no `<testsuites>` tag around the `<testsuite>` tag in the phpunit.xml file, the xpath query will find nothing.