### PR TITLE
Pass through ENV variables

### DIFF
--- a/src/Humbug/Adapter/Phpunit.php
+++ b/src/Humbug/Adapter/Phpunit.php
@@ -120,7 +120,7 @@ class Phpunit extends AdapterAbstract
             $timeout
         );
 
-        $process = new PhpProcess($job);
+        $process = new PhpProcess($job, null, $_ENV);
         $process->setTimeout($timeout);
 
         return $process;
@@ -140,9 +140,9 @@ class Phpunit extends AdapterAbstract
      */
     public static function main($arguments, $mutation = null)
     {
-        
+
         $arguments = unserialize(base64_decode($arguments));
-        
+
         /**
          * Grab the Runkit extension utility and apply the mutation if needed
          */
@@ -268,7 +268,7 @@ class Phpunit extends AdapterAbstract
         }
 
         if (!empty($cases)) {
-            
+
             // TODO: Handle >1 test suites
             $suite1 = $xpath->query('/phpunit/testsuites/testsuite')->item(0);
             foreach ($suite1->childNodes as $child) {
@@ -305,5 +305,5 @@ class Phpunit extends AdapterAbstract
         $dom->save($saveFile);
         return $saveFile;
     }
-    
+
 }


### PR DESCRIPTION
This fixes errors when exec etc. is used for example in test
bootstrapping that rely on ENV variables.

This only works if E is included in the ini setting 'variable_order'.
This probably should be fixed in PhpProcess to allow env forwarding by
setting the parameter $env to null.