### PR TITLE
Check exit code for phpunit failure

### DIFF
--- a/src/Humbug/Command/Humbug.php
+++ b/src/Humbug/Command/Humbug.php
@@ -42,7 +42,7 @@ class Humbug extends Command
 
         $this->validate($input, $output);
         $container = new Container($input, $output);
-        
+
         if ($input->hasOption('log-text')) {
             $renderer = new Text($output, true);
         } else {
@@ -64,7 +64,7 @@ class Humbug extends Command
          */
         $adapter = $container->getAdapter();
         $process = $adapter->runTests($container, true, true);
-        $process->run();
+        $exitCode = $process->run();
         $result = [ // default values
             'passed'    => true,
             'timeout'   => false,
@@ -80,22 +80,13 @@ class Humbug extends Command
         /**
          * Check if the initial test run ended with a fatal error
          */
-        if (!empty($result['stderr'])) {
-            $renderer->renderInitialRunError($result);
-            $this->logText($input, $renderer);
-            exit(1);
-        }
-
-        /**
-         * Check if the initial test run was not in a passing state
-         */
-        if ($result['passed'] === false) {
+        if ($exitCode !== 0) {
             $renderer->renderInitialRunFail($result);
             $this->logText($input, $renderer);
             exit(1);
         }
 
-        /** 
+        /**
          * Initial test run was a success!
          */
         $renderer->renderInitialRunPass($result);

--- a/src/Humbug/Renderer/Text.php
+++ b/src/Humbug/Renderer/Text.php
@@ -64,19 +64,6 @@ class Text
     }
 
     /**
-     * Render message where the initial test run experienced a fatal error.
-     *
-     * @param array $result
-     */
-    public function renderInitialRunError(array $result)
-    {
-        $this->write('<warning>Tests must be in a fully passing state before Humbug is run.</warning>');
-        $this->write('<warning>Incomplete, skipped or risky tests are allowed.</warning>');
-        $this->write('<error>An error has been experienced by Humbug during the initial test run:');
-        $this->write($result['stderr'].'</error>');
-    }
-
-    /**
      * Render message where the initial test run didn't pass (excl. incomplete/skipped/risky tests)
      *
      * @param array $result
@@ -85,7 +72,12 @@ class Text
     {
         $this->write('<warning>Tests must be in a fully passing state before Humbug is run.</warning>');
         $this->write('<warning>Incomplete, skipped or risky tests are allowed.</warning>');
-        $this->write('<warning>' . $this->indent($result['stdout']) . '</warning>');
+        if (!empty($result['stdout'])) {
+            $this->write('<warning>Stdout: \n' . $this->indent($result['stdout']) . '\n</warning>');
+        }
+        if (!empty($result['stderr'])) {
+            $this->write('<warning>Stderr: \n' . $this->indent($result['stderr']) . '\n</warning>');
+        }
     }
 
     /**
@@ -183,7 +175,7 @@ class Text
     /**
      * Render message that mutation testing loop is starting
      *
-     * 
+     *
      */
     public function renderSummaryReport($total, $kills, $escapes, $errors, $timeouts, $shadows)
     {
@@ -219,7 +211,7 @@ class Text
     /**
      * Render details concerning any escaped mutants or fatal errors encountered
      *
-     * 
+     *
      */
     public function renderDetailedReport(array $escaped)
     {
@@ -240,7 +232,7 @@ class Text
             $i++;
         }
     }
-    
+
     /**
      * Utility function to prefix output lines with an indent
      *


### PR DESCRIPTION
Don't use flaky output parsing:
 - Stderr may contain output from external commands while bootstrapping
   with merely warnings
 - Stdout parsing is too flaky if there are skipped tests.