### PR TITLE
Method return value in empty only work in PHP 5.5

### DIFF
--- a/src/Humbug/Adapter/Phpunit.php
+++ b/src/Humbug/Adapter/Phpunit.php
@@ -203,8 +203,9 @@ class Phpunit extends AdapterAbstract
     {
         $conf = null;
         $dir = null;
-        if (!empty($container->getTestDirectory())) {
-            $dir = $container->getTestDirectory();
+        $testDir = $container->getTestDirectory();
+        if (!empty($testDir)) {
+            $dir = $testDir;
             $conf = $dir . '/phpunit.xml';
         } elseif (!file_exists($conf)) {
             $dir = $container->getBaseDirectory();


### PR DESCRIPTION
Humbug reports to work on PHP 5.4, but method return values in `empty` is only supported in PHP >= 5.5