### PR TITLE
Check if files exist using glob

### DIFF
--- a/src/Humbug/Adapter/Phpunit.php
+++ b/src/Humbug/Adapter/Phpunit.php
@@ -249,7 +249,7 @@ class Phpunit extends AdapterAbstract
                 && ($node->tagName == 'directory'
                 || $node->tagName == 'exclude'
                 || $node->tagName == 'file')) {
-                    if (!file_exists($node->nodeValue)) {
+                    if (0 === count(glob($node->nodeValue))) {
                         throw new RuntimeException('Unable to locate file specified in testsuites: ' . $node->nodeValue);
                     }
 


### PR DESCRIPTION
Check if files exist using `glob` instead of `file_exists`, so it can work with E.G `../src/*/*Bundle/Tests` in the phpunit.xml config