### PR TITLE
PHP 5.4 short array syntax

### DIFF
--- a/src/Humbug/Utility/Performance.php
+++ b/src/Humbug/Utility/Performance.php
@@ -38,11 +38,11 @@ class Performance
 
     public static function getTimeString()
     {
-        $horizons = array(
+        $horizons = [
             'hour'   => 3600000,
             'minute' => 60000,
             'second' => 1000
-        );
+        ];
         $milliseconds = round(self::getTime() * 1000);
         foreach ($horizons as $unit => $value) {
             if ($milliseconds >= $value) {

--- a/src/Humbug/Utility/TestTimeAnalyser.php
+++ b/src/Humbug/Utility/TestTimeAnalyser.php
@@ -61,11 +61,11 @@ class TestTimeAnalyser
             // This may exclude data provision run data
             if ($case->hasAttribute('class')) { 
                 if (!isset($testCases[$case->getAttribute('class')])) {
-                    $testCases[$case->getAttribute('class')] = array(
+                    $testCases[$case->getAttribute('class')] = [
                         'class' => $case->getAttribute('class'),
                         'file' => $case->getAttribute('file'),
                         'time' => 0
-                    );
+                    ];
                 }
                 $testCases[$case->getAttribute('class')]['time'] += (float) $case->getAttribute('time');
             }

--- a/tests/Humbug/Test/GeneratorTest.php
+++ b/tests/Humbug/Test/GeneratorTest.php
@@ -50,10 +50,10 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new Generator;
         $generator->setSourceDirectory($this->root);
-        $this->assertEquals(array(
+        $this->assertEquals([
             $this->root . '/library/bool2.php',
             $this->root . '/library/bool1.php'
-        ),$generator->getFiles());
+        ],$generator->getFiles());
     }
 
     public function testShouldGenerateMutableFileObjects()
@@ -72,7 +72,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new Generator;
         $generator->setSourceDirectory($this->root);
-        $mutable = $this->getMock('Mutable', array('generate', 'setFilename'));
+        $mutable = $this->getMock('Mutable', ['generate', 'setFilename']);
         $generator->generate($mutable);
         $this->assertEquals(2, count($generator->getMutables()));
     }

--- a/tests/Humbug/Test/MutableTest.php
+++ b/tests/Humbug/Test/MutableTest.php
@@ -33,34 +33,34 @@ class MutableTest extends \PHPUnit_Framework_TestCase
     public function testShouldNotHaveMutationsBeforeGeneration()
     {
         $file = new Mutable($this->root . '/math1.php');
-        $this->assertEquals(array(), $file->getMutations());
+        $this->assertEquals([], $file->getMutations());
     }
 
     public function testShouldNotHaveDetectedMutablesBeforeGeneration()
     {
         $file = new Mutable($this->root . '/math1.php');
-        $this->assertEquals(array(), $file->getMutables());
+        $this->assertEquals([], $file->getMutables());
     }
 
     public function testShouldNotGenerateMutablesForEmptyClass()
     {
         $file = new Mutable($this->root . '/math0.php');
         $file->generate();
-        $this->assertEquals(array(), $file->getMutables());
+        $this->assertEquals([], $file->getMutables());
     }
 
     public function testShouldNotgenerateForEmptyClass()
     {
         $file = new Mutable($this->root . '/math0.php');
         $file->generate();
-        $this->assertEquals(array(), $file->getMutations());
+        $this->assertEquals([], $file->getMutations());
     }
 
     public function testShouldNotGenerateMutationsIfOnlyEmptyMethodsInClass()
     {
         $file = new Mutable($this->root . '/math00.php');
         $file->generate();
-        $this->assertEquals(array(), $file->getMutations());
+        $this->assertEquals([], $file->getMutations());
     }
 
     public function testShouldGenerateMutablesEvenIfMethodBodyIsNotViable()
@@ -68,14 +68,14 @@ class MutableTest extends \PHPUnit_Framework_TestCase
         $file = new Mutable($this->root . '/math000.php');
         $file->generate();
         $return = $file->getMutables();
-        $this->assertEquals(array('file','class','method','args','tokens'),array_keys($return[0]));
+        $this->assertEquals(['file','class','method','args','tokens'],array_keys($return[0]));
     }
 
     public function testShouldNotGenerateMutablesIfMethodBodyIsNotViable()
     {
         $file = new Mutable($this->root . '/math000.php');
         $file->generate();
-        $this->assertEquals(array(), $file->getMutations());
+        $this->assertEquals([], $file->getMutations());
     }
 
     public function testShouldGenerateAMutationIfPossible()
@@ -83,7 +83,7 @@ class MutableTest extends \PHPUnit_Framework_TestCase
         $file = new Mutable($this->root . '/math1.php');
         $file->generate();
         $return = $file->getMutations();
-        $this->assertEquals(array('file','class','method','args','tokens','index','mutation'),array_keys($return[0]));
+        $this->assertEquals(['file','class','method','args','tokens','index','mutation'],array_keys($return[0]));
     }
 
     public function testShouldReturnMutationsAsMutantObjectWrappers()

--- a/tests/Humbug/Test/Mutator/Arithmetic/AdditionTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/AdditionTest.php
@@ -20,20 +20,20 @@ class AdditionTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\Addition;
         $this->assertEquals(
-            array(
+            [
                 10 => '-'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesAdditionOperatorToSubtractionOperator()
     {
-        $tokens = array(10 => '+');
+        $tokens = [10 => '+'];
 
         $this->assertTrue(Mutator\Arithmetic\Addition::mutates($tokens, 10));
 
-        $tokens = array(11 => '-');
+        $tokens = [11 => '-'];
 
         $this->assertFalse(Mutator\Arithmetic\Addition::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/BitwiseAndTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/BitwiseAndTest.php
@@ -20,20 +20,20 @@ class BitwiseAndTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\BitwiseAnd;
         $this->assertEquals(
-            array(
+            [
                 10 => '|'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesBitwiseAndToBitwiseOr()
     {
-        $tokens = array(10 => '&');
+        $tokens = [10 => '&'];
 
         $this->assertTrue(Mutator\Arithmetic\BitwiseAnd::mutates($tokens, 10));
 
-        $tokens = array(11 => '|');
+        $tokens = [11 => '|'];
 
         $this->assertFalse(Mutator\Arithmetic\BitwiseAnd::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/BitwiseOrTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/BitwiseOrTest.php
@@ -20,20 +20,20 @@ class BitwiseOrTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\BitwiseOr;
         $this->assertEquals(
-            array(
+            [
                 10 => '&'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesBitwiseOrToBitwiseAnd()
     {
-        $tokens = array(10 => '|');
+        $tokens = [10 => '|'];
 
         $this->assertTrue(Mutator\Arithmetic\BitwiseOr::mutates($tokens, 10));
 
-        $tokens = array(11 => '&');
+        $tokens = [11 => '&'];
 
         $this->assertFalse(Mutator\Arithmetic\BitwiseOr::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/BitwiseXorTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/BitwiseXorTest.php
@@ -20,20 +20,20 @@ class BitwiseXorTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\BitwiseXor;
         $this->assertEquals(
-            array(
+            [
                 10 => '&'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesBitwiseXorToBitwiseAnd()
     {
-        $tokens = array(10 => '^');
+        $tokens = [10 => '^'];
 
         $this->assertTrue(Mutator\Arithmetic\BitwiseXor::mutates($tokens, 10));
 
-        $tokens = array(11 => '&');
+        $tokens = [11 => '&'];
 
         $this->assertFalse(Mutator\Arithmetic\BitwiseXor::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/DivEqualTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/DivEqualTest.php
@@ -20,20 +20,20 @@ class DivEqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\DivEqual;
         $this->assertEquals(
-            array(
-                10 => array(T_MUL_EQUAL, '*=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_MUL_EQUAL, '*=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesDivEqualToMulEqual()
     {
-        $tokens = array(10 => array(T_DIV_EQUAL, '/='));
+        $tokens = [10 => [T_DIV_EQUAL, '/=']];
 
         $this->assertTrue(Mutator\Arithmetic\DivEqual::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_MUL_EQUAL, '*='));
+        $tokens = [11 => [T_MUL_EQUAL, '*=']];
 
         $this->assertFalse(Mutator\Arithmetic\DivEqual::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/DivisionTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/DivisionTest.php
@@ -20,20 +20,20 @@ class DivisionTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\Division;
         $this->assertEquals(
-            array(
+            [
                 10 => '*'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesDivisionToMultiplication()
     {
-        $tokens = array(10 => '/');
+        $tokens = [10 => '/'];
 
         $this->assertTrue(Mutator\Arithmetic\Division::mutates($tokens, 10));
 
-        $tokens = array(11 => '*');
+        $tokens = [11 => '*'];
 
         $this->assertFalse(Mutator\Arithmetic\Division::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/ExponentiationTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/ExponentiationTest.php
@@ -20,10 +20,10 @@ class ExponentiationTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\Exponentiation;
         $this->assertEquals(
-            array(
+            [
                 10 => '/'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
@@ -33,11 +33,11 @@ class ExponentiationTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped();
         }
 
-        $tokens = array(10 => array(T_POW));
+        $tokens = [10 => [T_POW]];
 
         $this->assertTrue(Mutator\Arithmetic\Exponentiation::mutates($tokens, 10));
 
-        $tokens = array(11 => '/');
+        $tokens = [11 => '/'];
 
         $this->assertFalse(Mutator\Arithmetic\Exponentiation::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/MinusEqualTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/MinusEqualTest.php
@@ -20,20 +20,20 @@ class MinusEqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\MinusEqual;
         $this->assertEquals(
-            array(
-                10 => array(T_PLUS_EQUAL, '+=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_PLUS_EQUAL, '+=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesMinusEqualToPlusEqual()
     {
-        $tokens = array(10 => array(T_MINUS_EQUAL, '-='));
+        $tokens = [10 => [T_MINUS_EQUAL, '-=']];
 
         $this->assertTrue(Mutator\Arithmetic\MinusEqual::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_PLUS_EQUAL, '+='));
+        $tokens = [11 => [T_PLUS_EQUAL, '+=']];
 
         $this->assertFalse(Mutator\Arithmetic\MinusEqual::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/ModEqualTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/ModEqualTest.php
@@ -20,20 +20,20 @@ class ModEqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\ModEqual;
         $this->assertEquals(
-            array(
-                10 => array(T_MUL_EQUAL, '*=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_MUL_EQUAL, '*=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesModEqualToMulEqual()
     {
-        $tokens = array(10 => array(T_MOD_EQUAL, '%='));
+        $tokens = [10 => [T_MOD_EQUAL, '%=']];
 
         $this->assertTrue(Mutator\Arithmetic\ModEqual::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_MUL_EQUAL, '*='));
+        $tokens = [11 => [T_MUL_EQUAL, '*=']];
 
         $this->assertFalse(Mutator\Arithmetic\ModEqual::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/ModulusTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/ModulusTest.php
@@ -20,20 +20,20 @@ class ModulusTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\Modulus;
         $this->assertEquals(
-            array(
+            [
                 10 => '*'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesModulusToMultiplication()
     {
-        $tokens = array(10 => '%');
+        $tokens = [10 => '%'];
 
         $this->assertTrue(Mutator\Arithmetic\Modulus::mutates($tokens, 10));
 
-        $tokens = array(11 => '*');
+        $tokens = [11 => '*'];
 
         $this->assertFalse(Mutator\Arithmetic\Modulus::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/MulEqualTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/MulEqualTest.php
@@ -20,20 +20,20 @@ class MulEqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\MulEqual;
         $this->assertEquals(
-            array(
-                10 => array(T_DIV_EQUAL, '/=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_DIV_EQUAL, '/=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesMulEqualToDivEqual()
     {
-        $tokens = array(10 => array(T_MUL_EQUAL, '*='));
+        $tokens = [10 => [T_MUL_EQUAL, '*=']];
 
         $this->assertTrue(Mutator\Arithmetic\MulEqual::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_DIV_EQUAL, '/='));
+        $tokens = [11 => [T_DIV_EQUAL, '/=']];
 
         $this->assertFalse(Mutator\Arithmetic\MulEqual::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/MultiplicationTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/MultiplicationTest.php
@@ -20,20 +20,20 @@ class MultiplicationTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\Multiplication;
         $this->assertEquals(
-            array(
+            [
                 10 => '/'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesMultiplicationToDivision()
     {
-        $tokens = array(10 => '*');
+        $tokens = [10 => '*'];
 
         $this->assertTrue(Mutator\Arithmetic\Multiplication::mutates($tokens, 10));
 
-        $tokens = array(11 => '/');
+        $tokens = [11 => '/'];
 
         $this->assertFalse(Mutator\Arithmetic\Multiplication::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/NotTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/NotTest.php
@@ -20,16 +20,16 @@ class NotTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\Not;
         $this->assertEquals(
-            array(
-                10 => array(T_WHITESPACE, '')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_WHITESPACE, '']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesNotToWhitespace()
     {
-        $tokens = array(10 => '~');
+        $tokens = [10 => '~'];
 
         $this->assertTrue(Mutator\Arithmetic\Not::mutates($tokens, 10));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/PlusEqualTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/PlusEqualTest.php
@@ -20,20 +20,20 @@ class PlusEqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\PlusEqual;
         $this->assertEquals(
-            array(
-                10 => array(T_MINUS_EQUAL, '-=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_MINUS_EQUAL, '-=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesPlusEqualToMinusEqual()
     {
-        $tokens = array(10 => array(T_PLUS_EQUAL, '+='));
+        $tokens = [10 => [T_PLUS_EQUAL, '+=']];
 
         $this->assertTrue(Mutator\Arithmetic\PlusEqual::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_MINUS_EQUAL, '-='));
+        $tokens = [11 => [T_MINUS_EQUAL, '-=']];
 
         $this->assertFalse(Mutator\Arithmetic\PlusEqual::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/PowEqualTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/PowEqualTest.php
@@ -20,10 +20,10 @@ class PowEqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\PowEqual;
         $this->assertEquals(
-            array(
-                10 => array(T_DIV_EQUAL, '/=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_DIV_EQUAL, '/=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
@@ -33,11 +33,11 @@ class PowEqualTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped();
         }
 
-        $tokens = array(10 => array(T_POW_EQUAL, '**='));
+        $tokens = [10 => [T_POW_EQUAL, '**=']];
 
         $this->assertTrue(Mutator\Arithmetic\PowEqual::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_DIV_EQUAL, '/='));
+        $tokens = [11 => [T_DIV_EQUAL, '/=']];
 
         $this->assertFalse(Mutator\Arithmetic\PowEqual::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/ShiftLeftTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/ShiftLeftTest.php
@@ -20,20 +20,20 @@ class ShiftLeftTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\ShiftLeft;
         $this->assertEquals(
-            array(
-                10 => array(T_SR, '>>')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_SR, '>>']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesShiftLeftToShiftRight()
     {
-        $tokens = array(10 => array(T_SL, '<<'));
+        $tokens = [10 => [T_SL, '<<']];
 
         $this->assertTrue(Mutator\Arithmetic\ShiftLeft::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_SR, '>>'));
+        $tokens = [11 => [T_SR, '>>']];
 
         $this->assertFalse(Mutator\Arithmetic\ShiftLeft::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/ShiftRightTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/ShiftRightTest.php
@@ -20,20 +20,20 @@ class ShiftRightTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\ShiftRight;
         $this->assertEquals(
-            array(
-                10 => array(T_SL, '<<')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_SL, '<<']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesShiftRightToShiftLeft()
     {
-        $tokens = array(10 => array(T_SR, '>>'));
+        $tokens = [10 => [T_SR, '>>']];
 
         $this->assertTrue(Mutator\Arithmetic\ShiftRight::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_SL, '<<'));
+        $tokens = [11 => [T_SL, '<<']];
 
         $this->assertFalse(Mutator\Arithmetic\ShiftRight::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Arithmetic/SubtractionTest.php
+++ b/tests/Humbug/Test/Mutator/Arithmetic/SubtractionTest.php
@@ -20,20 +20,20 @@ class SubtractionTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Arithmetic\Subtraction;
         $this->assertEquals(
-            array(
+            [
                 10 => '+'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesSubtractionOperatorToAdditionOperator()
     {
-        $tokens = array(10 => '-');
+        $tokens = [10 => '-'];
 
         $this->assertTrue(Mutator\Arithmetic\Subtraction::mutates($tokens, 10));
 
-        $tokens = array(11 => '+');
+        $tokens = [11 => '+'];
 
         $this->assertFalse(Mutator\Arithmetic\Subtraction::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Boolean/FalseTest.php
+++ b/tests/Humbug/Test/Mutator/Boolean/FalseTest.php
@@ -20,22 +20,22 @@ class FalseTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Boolean\False;
         $this->assertEquals(
-            array(
-                10 => array(
+            [
+                10 => [
                     T_STRING, 'true'
-                )
-            ),
-            $mutation->getMutation(array(), 10)
+                ]
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesFalseToTrue()
     {
-        $tokens = array(10 => array(T_STRING, 'FALSE'));
+        $tokens = [10 => [T_STRING, 'FALSE']];
 
         $this->assertTrue(Mutator\Boolean\False::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_STRING, 'TRUE'));
+        $tokens = [11 => [T_STRING, 'TRUE']];
 
         $this->assertFalse(Mutator\Boolean\False::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Boolean/LogicalAndTest.php
+++ b/tests/Humbug/Test/Mutator/Boolean/LogicalAndTest.php
@@ -20,20 +20,20 @@ class LogicalAndTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Boolean\LogicalAnd;
         $this->assertEquals(
-            array(
-                10 => array(T_BOOLEAN_OR, '||')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_BOOLEAN_OR, '||']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesLogicalAndToLogicalOr()
     {
-        $tokens = array(10 => array(T_BOOLEAN_AND, '&&'));
+        $tokens = [10 => [T_BOOLEAN_AND, '&&']];
 
         $this->assertTrue(Mutator\Boolean\LogicalAnd::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_BOOLEAN_OR, '||'));
+        $tokens = [11 => [T_BOOLEAN_OR, '||']];
 
         $this->assertFalse(Mutator\Boolean\LogicalAnd::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/Humbug/Test/Mutator/Boolean/LogicalOrTest.php
@@ -20,20 +20,20 @@ class LogicalOrTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Boolean\LogicalOr;
         $this->assertEquals(
-            array(
-                10 => array(T_BOOLEAN_AND, '&&')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_BOOLEAN_AND, '&&']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesLogicalOrToLogicalAnd()
     {
-        $tokens = array(10 => array(T_BOOLEAN_OR, '||'));
+        $tokens = [10 => [T_BOOLEAN_OR, '||']];
 
         $this->assertTrue(Mutator\Boolean\LogicalOr::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_BOOLEAN_AND, '&&'));
+        $tokens = [11 => [T_BOOLEAN_AND, '&&']];
 
         $this->assertFalse(Mutator\Boolean\LogicalOr::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Boolean/TrueTest.php
+++ b/tests/Humbug/Test/Mutator/Boolean/TrueTest.php
@@ -20,22 +20,22 @@ class TrueTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Boolean\True;
         $this->assertEquals(
-            array(
-                10 => array(
+            [
+                10 => [
                     T_STRING, 'false'
-                )
-            ),
-            $mutation->getMutation(array(), 10)
+                ]
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesTrueToFalse()
     {
-        $tokens = array(10 => array(T_STRING, 'TRUE'));
+        $tokens = [10 => [T_STRING, 'TRUE']];
 
         $this->assertTrue(Mutator\Boolean\True::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_STRING, 'FALSE'));
+        $tokens = [11 => [T_STRING, 'FALSE']];
 
         $this->assertFalse(Mutator\Boolean\True::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
@@ -20,20 +20,20 @@ class GreaterThanOrEqualToTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalBoundary\GreaterThanOrEqualTo;
         $this->assertEquals(
-            array(
+            [
                 10 => '>'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesGreaterThanToGreaterThanOrEqualTo()
     {
-        $tokens = array(10 => array(T_IS_GREATER_OR_EQUAL, '>='));
+        $tokens = [10 => [T_IS_GREATER_OR_EQUAL, '>=']];
 
         $this->assertTrue(Mutator\ConditionalBoundary\GreaterThanOrEqualTo::mutates($tokens, 10));
 
-        $tokens = array(11 => '>');
+        $tokens = [11 => '>'];
 
         $this->assertFalse(Mutator\ConditionalBoundary\GreaterThanOrEqualTo::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalBoundary/GreaterThanTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalBoundary/GreaterThanTest.php
@@ -20,20 +20,20 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalBoundary\GreaterThan;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_GREATER_OR_EQUAL, '>=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_GREATER_OR_EQUAL, '>=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesGreaterThanToGreaterThanOrEqualTo()
     {
-        $tokens = array(10 => '>');
+        $tokens = [10 => '>'];
 
         $this->assertTrue(Mutator\ConditionalBoundary\GreaterThan::mutates($tokens, 10));
 
-        $tokens = array(11 => '>=');
+        $tokens = [11 => '>='];
 
         $this->assertFalse(Mutator\ConditionalBoundary\GreaterThan::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
@@ -20,20 +20,20 @@ class LessThanOrEqualToTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalBoundary\LessThanOrEqualTo;
         $this->assertEquals(
-            array(
+            [
                 10 => '<'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesLessThanToLessThanOrEqualTo()
     {
-        $tokens = array(10 => array(T_IS_SMALLER_OR_EQUAL, '<='));
+        $tokens = [10 => [T_IS_SMALLER_OR_EQUAL, '<=']];
 
         $this->assertTrue(Mutator\ConditionalBoundary\LessThanOrEqualTo::mutates($tokens, 10));
 
-        $tokens = array(11 => '<');
+        $tokens = [11 => '<'];
 
         $this->assertFalse(Mutator\ConditionalBoundary\LessThanOrEqualTo::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalBoundary/LessThanTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalBoundary/LessThanTest.php
@@ -20,20 +20,20 @@ class LessThanTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalBoundary\LessThan;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_SMALLER_OR_EQUAL, '<=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_SMALLER_OR_EQUAL, '<=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesLessThanToLessThanOrEqualTo()
     {
-        $tokens = array(10 => '<');
+        $tokens = [10 => '<'];
 
         $this->assertTrue(Mutator\ConditionalBoundary\LessThan::mutates($tokens, 10));
 
-        $tokens = array(11 => '<=');
+        $tokens = [11 => '<='];
 
         $this->assertFalse(Mutator\ConditionalBoundary\LessThan::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/EqualTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/EqualTest.php
@@ -20,20 +20,20 @@ class EqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\Equal;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_NOT_EQUAL, '!=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_NOT_EQUAL, '!=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesEqualToNotEqual()
     {
-        $tokens = array(10 => array(T_IS_EQUAL, '=='));
+        $tokens = [10 => [T_IS_EQUAL, '==']];
 
         $this->assertTrue(Mutator\ConditionalNegation\Equal::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_IS_NOT_EQUAL, '!='));
+        $tokens = [11 => [T_IS_NOT_EQUAL, '!=']];
 
         $this->assertFalse(Mutator\ConditionalNegation\Equal::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/GreaterThanOrEqualToTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/GreaterThanOrEqualToTest.php
@@ -20,20 +20,20 @@ class GreaterThanOrEqualToTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\GreaterThanOrEqualTo;
         $this->assertEquals(
-            array(
+            [
                 10 => '<'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesGreaterThanOrEqualToToLessThan()
     {
-        $tokens = array(10 => array(T_IS_GREATER_OR_EQUAL, '>='));
+        $tokens = [10 => [T_IS_GREATER_OR_EQUAL, '>=']];
 
         $this->assertTrue(Mutator\ConditionalNegation\GreaterThanOrEqualTo::mutates($tokens, 10));
 
-        $tokens = array(11 => '<');
+        $tokens = [11 => '<'];
 
         $this->assertFalse(Mutator\ConditionalNegation\GreaterThanOrEqualTo::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/GreaterThanTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/GreaterThanTest.php
@@ -20,20 +20,20 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\GreaterThan;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_SMALLER_OR_EQUAL, '<=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_SMALLER_OR_EQUAL, '<=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesGreaterThanToLessThanOrEqualTo()
     {
-        $tokens = array(10 => '>');
+        $tokens = [10 => '>'];
 
         $this->assertTrue(Mutator\ConditionalNegation\GreaterThan::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_IS_SMALLER_OR_EQUAL, '<='));
+        $tokens = [11 => [T_IS_SMALLER_OR_EQUAL, '<=']];
 
         $this->assertFalse(Mutator\ConditionalNegation\GreaterThan::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/IdenticalTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/IdenticalTest.php
@@ -20,20 +20,20 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\Identical;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_NOT_IDENTICAL, '!==')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_NOT_IDENTICAL, '!==']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesIdenticalToNotIdentical()
     {
-        $tokens = array(10 => array(T_IS_IDENTICAL, '==='));
+        $tokens = [10 => [T_IS_IDENTICAL, '===']];
 
         $this->assertTrue(Mutator\ConditionalNegation\Identical::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_IS_NOT_IDENTICAL, '!=='));
+        $tokens = [11 => [T_IS_NOT_IDENTICAL, '!==']];
 
         $this->assertFalse(Mutator\ConditionalNegation\Identical::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/LessThanOrEqualToTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/LessThanOrEqualToTest.php
@@ -20,20 +20,20 @@ class LessThanOrEqualToTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\LessThanOrEqualTo;
         $this->assertEquals(
-            array(
+            [
                 10 => '>'
-            ),
-            $mutation->getMutation(array(), 10)
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesLessThanOrEqualToToGreaterThan()
     {
-        $tokens = array(10 => array(T_IS_SMALLER_OR_EQUAL, '<='));
+        $tokens = [10 => [T_IS_SMALLER_OR_EQUAL, '<=']];
 
         $this->assertTrue(Mutator\ConditionalNegation\LessThanOrEqualTo::mutates($tokens, 10));
 
-        $tokens = array(11 => '>');
+        $tokens = [11 => '>'];
 
         $this->assertFalse(Mutator\ConditionalNegation\LessThanOrEqualTo::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/LessThanTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/LessThanTest.php
@@ -20,20 +20,20 @@ class LessThanTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\LessThan;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_GREATER_OR_EQUAL, '>=')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_GREATER_OR_EQUAL, '>=']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesLessThanToGreaterThanOrEqualTo()
     {
-        $tokens = array(10 => '<');
+        $tokens = [10 => '<'];
 
         $this->assertTrue(Mutator\ConditionalNegation\LessThan::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_IS_GREATER_OR_EQUAL, '>='));
+        $tokens = [11 => [T_IS_GREATER_OR_EQUAL, '>=']];
 
         $this->assertFalse(Mutator\ConditionalNegation\LessThan::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/NotEqualTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/NotEqualTest.php
@@ -20,20 +20,20 @@ class NotEqualTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\NotEqual;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_EQUAL, '==')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_EQUAL, '==']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesNotEqualToEqual()
     {
-        $tokens = array(10 => array(T_IS_NOT_EQUAL, '!='));
+        $tokens = [10 => [T_IS_NOT_EQUAL, '!=']];
 
         $this->assertTrue(Mutator\ConditionalNegation\NotEqual::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_IS_EQUAL, '=='));
+        $tokens = [11 => [T_IS_EQUAL, '==']];
 
         $this->assertFalse(Mutator\ConditionalNegation\NotEqual::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/ConditionalNegation/NotIdenticalTest.php
+++ b/tests/Humbug/Test/Mutator/ConditionalNegation/NotIdenticalTest.php
@@ -20,20 +20,20 @@ class NotIdenticalTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\ConditionalNegation\NotIdentical;
         $this->assertEquals(
-            array(
-                10 => array(T_IS_IDENTICAL, '===')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_IS_IDENTICAL, '===']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesNotIdenticalToIdentical()
     {
-        $tokens = array(10 => array(T_IS_NOT_IDENTICAL, '!=='));
+        $tokens = [10 => [T_IS_NOT_IDENTICAL, '!==']];
 
         $this->assertTrue(Mutator\ConditionalNegation\NotIdentical::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_IS_IDENTICAL, '==='));
+        $tokens = [11 => [T_IS_IDENTICAL, '===']];
 
         $this->assertFalse(Mutator\ConditionalNegation\NotIdentical::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Increment/DecrementTest.php
+++ b/tests/Humbug/Test/Mutator/Increment/DecrementTest.php
@@ -20,20 +20,20 @@ class DecrementTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Increment\Decrement;
         $this->assertEquals(
-            array(
-                10 => array(T_INC, '++')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_INC, '++']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesDecrementToIncrement()
     {
-        $tokens = array(10 => array(T_DEC, '--'));
+        $tokens = [10 => [T_DEC, '--']];
 
         $this->assertTrue(Mutator\Increment\Decrement::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_INC, '++'));
+        $tokens = [11 => [T_INC, '++']];
 
         $this->assertFalse(Mutator\Increment\Decrement::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/Mutator/Increment/IncrementTest.php
+++ b/tests/Humbug/Test/Mutator/Increment/IncrementTest.php
@@ -20,20 +20,20 @@ class IncrementTest extends \PHPUnit_Framework_TestCase
     {
         $mutation = new Mutator\Increment\Increment;
         $this->assertEquals(
-            array(
-                10 => array(T_DEC, '--')
-            ),
-            $mutation->getMutation(array(), 10)
+            [
+                10 => [T_DEC, '--']
+            ],
+            $mutation->getMutation([], 10)
         );
     }
 
     public function testMutatesIncrementToDecrement()
     {
-        $tokens = array(10 => array(T_INC, '++'));
+        $tokens = [10 => [T_INC, '++']];
 
         $this->assertTrue(Mutator\Increment\Increment::mutates($tokens, 10));
 
-        $tokens = array(11 => array(T_DEC, '--'));
+        $tokens = [11 => [T_DEC, '--']];
 
         $this->assertFalse(Mutator\Increment\Increment::mutates($tokens, 11));
     }

--- a/tests/Humbug/Test/RunkitTest.php
+++ b/tests/Humbug/Test/RunkitTest.php
@@ -24,15 +24,15 @@ class RunkitTest extends \PHPUnit_Framework_TestCase
     
     public function testShouldApplyGivenMutationsUsingRunkitToReplaceEffectedMethods()
     {
-        $mutation = array(
+        $mutation = [
             'file' => $this->root . '/runkit/Math1.php',
             'class' => 'RunkitTest_Math1',
             'method' => 'add',
             'args' => '$op1,$op2',
-            'tokens' => array(array(335,'return',7), array(309,'$op1',7), '+', array(309,'$op2',7), ';'),
+            'tokens' => [[335,'return',7], [309,'$op1',7], '+', [309,'$op2',7], ';'],
             'index' => 2,
             'mutation' => new Mutator\Arithmetic\Addition($this->root . '/runkit/Math1.php')
-        );
+        ];
         require_once $mutation['file'];
         $runkit = new Runkit;
         $runkit->applyMutation($mutation);
@@ -43,15 +43,15 @@ class RunkitTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldRevertToOriginalMethodBodyWhenRequested()
     {
-        $mutation = array(
+        $mutation = [
             'file' => $this->root . '/runkit/Math1.php',
             'class' => 'RunkitTest_Math1',
             'method' => 'add',
             'args' => '$op1,$op2',
-            'tokens' => array(array(335,'return',7), array(309,'$op1',7), '+', array(309,'$op2',7), ';'),
+            'tokens' => [[335,'return',7], [309,'$op1',7], '+', [309,'$op2',7], ';'],
             'index' => 2,
             'mutation' => new Mutator\Arithmetic\Addition($this->root . '/runkit/Math1.php')
-        );
+        ];
         require_once $mutation['file'];
         $runkit = new Runkit;
         $runkit->applyMutation($mutation);
@@ -62,15 +62,15 @@ class RunkitTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldApplyGivenMutationsUsingRunkitToReplaceEffectedStaticMethods()
     {
-        $mutation = array(
+        $mutation = [
             'file' => $this->root . '/runkit/Math2.php',
             'class' => 'RunkitTest_Math2',
             'method' => 'add',
             'args' => '$op1,$op2',
-            'tokens' => array(array(335,'return',7), array(309,'$op1',7), '+', array(309,'$op2',7), ';'),
+            'tokens' => [[335,'return',7], [309,'$op1',7], '+', [309,'$op2',7], ';'],
             'index' => 2,
             'mutation' => new Mutator\Arithmetic\Addition($this->root . '/runkit/Math2.php')
-        );
+        ];
         require_once $mutation['file'];
         $runkit = new Runkit;
         $runkit->applyMutation($mutation);
@@ -80,15 +80,15 @@ class RunkitTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldRevertToOriginalStaticMethodBodyWhenRequested()
     {
-        $mutation = array(
+        $mutation = [
             'file' => $this->root . '/runkit/Math2.php',
             'class' => 'RunkitTest_Math2',
             'method' => 'add',
             'args' => '$op1,$op2',
-            'tokens' => array(array(335,'return',7), array(309,'$op1',7), '+', array(309,'$op2',7), ';'),
+            'tokens' => [[335,'return',7], [309,'$op1',7], '+', [309,'$op2',7], ';'],
             'index' => 2,
             'mutation' => new Mutator\Arithmetic\Addition($this->root . '/runkit/Math2.php')
-        );
+        ];
         require_once $mutation['file'];
         $runkit = new Runkit;
         $runkit->applyMutation($mutation);

--- a/tests/Humbug/Test/Utility/JobTest.php
+++ b/tests/Humbug/Test/Utility/JobTest.php
@@ -18,7 +18,7 @@ class JobTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateReturnsPHPScriptRenderedWithCurrentRunnersSettingsAndSerialisedMutationArray()
     {
-        $script = Job::generate(array('a', '1', new \stdClass), [], '/path/to/bootstrap.php');
+        $script = Job::generate(['a', '1', new \stdClass], [], '/path/to/bootstrap.php');
         $bootstrap = realpath(__DIR__ . '/../../../../src/bootstrap.php');
         $expected = <<<EXPECTED
 <?php

--- a/tests/Humbug/Test/_files/IdunToken.php
+++ b/tests/Humbug/Test/_files/IdunToken.php
@@ -322,7 +322,7 @@ class Idun_Form_Helper_Token
         }
         
         if (!isset($session->tokens) || !is_array($session->tokens)) {
-            $session->tokens = array();
+            $session->tokens = [];
         }
         
         return $session;


### PR DESCRIPTION
as requirement is PHP >=5.4.0, and for consistencies.