### PR TITLE
Full path for glob when running with chdir

### DIFF
--- a/src/Humbug/Adapter/Phpunit/XmlConfiguration.php
+++ b/src/Humbug/Adapter/Phpunit/XmlConfiguration.php
@@ -100,7 +100,7 @@ class XmlConfiguration
                 || $node->tagName == 'exclude'
                 || $node->tagName == 'file')) {
                     $fullPath = $dir . '/' . $node->nodeValue;
-                    if (0 === count(glob($node->nodeValue))) {
+                    if (0 === count(glob($fullPath))) {
                         throw new RuntimeException('Unable to locate file specified in testsuites: ' . $node->nodeValue);
                     }
 

--- a/src/Humbug/Adapter/Phpunit/XmlConfiguration.php
+++ b/src/Humbug/Adapter/Phpunit/XmlConfiguration.php
@@ -99,6 +99,7 @@ class XmlConfiguration
                 && ($node->tagName == 'directory'
                 || $node->tagName == 'exclude'
                 || $node->tagName == 'file')) {
+                    $fullPath = $dir . '/' . $node->nodeValue;
                     if (0 === count(glob($node->nodeValue))) {
                         throw new RuntimeException('Unable to locate file specified in testsuites: ' . $node->nodeValue);
                     }


### PR DESCRIPTION
When humbug is running with chdir we need to add this dir to every node value of phpunit.xml since they have relative paths. Otherwise we have 

    [Humbug\Exception\RuntimeException]
    Unable to locate file specified in testsuites: Events/Test