### PR TITLE
Avoid creating mutations on array union

### DIFF
--- a/tests/Humbug/Test/MutableTest.php
+++ b/tests/Humbug/Test/MutableTest.php
@@ -162,6 +162,13 @@ class MutableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('\Humbug\Mutator\ReturnValue\False', $return[0]['mutator']);
     }
 
+    public function testShoultNotGenerateMutableOnArrayConcatenation()
+    {
+        $file = new Mutable($this->root . '/array1.php');
+        $file->generate();
+        $this->assertEquals([], $file->getMutations());
+    }
+
     /**
      * Covers bug where Mutable may incorrectly parse a method and omit the first
      * opening bracket in an IF clause, leading to syntax errors when

--- a/tests/Humbug/Test/_files/root/base2/library/array1.php
+++ b/tests/Humbug/Test/_files/root/base2/library/array1.php
@@ -1,0 +1,14 @@
+<?php
+
+class Array1
+{
+    public function arrayConcatenate($op1)
+    {
+        $add1 = ['foo' => 'x'] + array('bar' => 'x');
+
+        $add2 = ['foo' => 'x'] + ['bar' => 'x'];
+
+        $add3 = ['foo' => 'x'] +
+            ['bar' => 'x'];
+    }
+}


### PR DESCRIPTION
With this change. Humbug avoids creating a mutation when it encounters something like:

```php
['foo' => 'x'] + ['bar' => 'x']
```
Which created an exception when mutated to:
```php
['foo' => 'x'] - ['bar' => 'x']
```