### PR TITLE
Allow to return the real path of folders containing wildcards.

### DIFF
--- a/src/Humbug/Adapter/Phpunit/XmlConfiguration.php
+++ b/src/Humbug/Adapter/Phpunit/XmlConfiguration.php
@@ -299,7 +299,7 @@ class XmlConfiguration
         }
 
         $relativePath = $workingDir.DIRECTORY_SEPARATOR.$name;
-        if (file_exists($relativePath)) {
+        if (file_exists($relativePath) || !empty(glob($relativePath))) {
             return realpath($relativePath);
         }
 


### PR DESCRIPTION
I am using the following configuration:

```
{
    "timeout": 10, 
    "source": {
        "directories": [
            "." 
        ],  
        "excludes": [
            "humbug",
            "vendor"
        ]   
    },  
    "logs": {
        "text": "humbuglog.txt"
    }   
}
```

When I run humbug it throws an exception when it tries to resolve a path with a wildcard. This is because it is using `file_exists()` which cannot handle paths with wildcards:

```
[Humbug\Exception\InvalidArgumentException]                                           
  Could not find file ./modules/*/tests working from /home/pieter/drupal/core
```

This can be solved by falling back to using `glob()` to check if any files exist that match the wildcard path.