### PR TITLE
Fixes GeneratorTest::testShouldCollateAllFilesValidForMutationTesting()

### DIFF
--- a/tests/Humbug/Test/GeneratorTest.php
+++ b/tests/Humbug/Test/GeneratorTest.php
@@ -40,8 +40,8 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new Generator;
         $generator->generate($finder);
         $this->assertEquals([
-            $this->root . '/library/bool2.php',
-            $this->root . '/library/bool1.php'
+            new Mutable($this->root . '/library/bool1.php'),
+            new Mutable($this->root . '/library/bool2.php')
         ],$generator->getMutables());
     }
 


### PR DESCRIPTION
as <code>Generate::getMutables()</code> returns array of Mutable objects.