### PR TITLE
Fix assertion message to show the missing file.

### DIFF
--- a/src/Humbug/Utility/CoverageData.php
+++ b/src/Humbug/Utility/CoverageData.php
@@ -28,13 +28,12 @@ class CoverageData
      */
     public function __construct($file, TestTimeAnalyser $analyser)
     {
-        $file = realpath($file);
-        if (!file_exists($file)) {
+        if (!$path = realpath($file)) {
             throw new InvalidArgumentException(
                 'File does not exist: ' . $file
             );
         }
-        $this->process($file);
+        $this->process($path);
         $this->analyser = $analyser;
     }
 


### PR DESCRIPTION
When the coverage file is missing the exception that is thrown in `CoverageData::__construct()` uses the output from `realpath()` to create the exception message. However if the file is missing `realpath()` returns `FALSE ` so the filename appears empty.