### PR TITLE
Prefix PHP command line with 'exec', resolves #63

### DIFF
--- a/src/Humbug/Adapter/Phpunit.php
+++ b/src/Humbug/Adapter/Phpunit.php
@@ -15,6 +15,7 @@ use Humbug\Adapter\Phpunit\XmlConfiguration;
 use Humbug\Utility\Job;
 use Humbug\Utility\TestTimeAnalyser;
 use Humbug\Utility\CoverageData;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\PhpProcess;
 
 class Phpunit extends AdapterAbstract
@@ -114,7 +115,13 @@ class Phpunit extends AdapterAbstract
             $interceptFile
         );
 
+        $executableFinder = new PhpExecutableFinder();
+        $php = $executableFinder->find();
+
         $process = new PhpProcess($job, null, $_ENV);
+        if ($php !== false) {
+            $process->setCommandLine('exec '.$php);
+        }
         $process->setTimeout($timeout);
 
         return $process;


### PR DESCRIPTION
This works on my machine. I don't know if it breaks on Windows.