### PR TITLE
Switch to PSR-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
         "mockery/mockery": "~0.9"
     },
     "autoload": {
-        "psr-0": { "Humbug\\": "src/" }
+        "psr-4": { "Humbug\\": "src/Humbug" }
     },
     "autoload-dev": {
-        "psr-0": { "Humbug\\Test\\": "tests/" }
+        "psr-4": { "Humbug\\Test\\": "tests/Humbug/Test" }
     },
     "bin": ["bin/humbug"],
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
         "mockery/mockery": "~0.9"
     },
     "autoload": {
-        "psr-4": { "Humbug\\": "src/Humbug" }
+        "psr-4": { "Humbug\\": "src/Humbug/" }
     },
     "autoload-dev": {
-        "psr-4": { "Humbug\\Test\\": "tests/Humbug/Test" }
+        "psr-4": { "Humbug\\Test\\": "tests/Humbug/Test/" }
     },
     "bin": ["bin/humbug"],
     "extra": {


### PR DESCRIPTION
PSR-4 allows for shallower directory structures, which is (intentionally) not included in this PR.