### PR TITLE
Issue/code cleanups

### DIFF
--- a/src/Humbug/Command/Humbug.php
+++ b/src/Humbug/Command/Humbug.php
@@ -53,7 +53,7 @@ class Humbug extends Command
         Performance::upMemProfiler();
         $output->writeln($this->getApplication()->getLongVersion() . PHP_EOL);
 
-        $this->validate($input, $output);
+        $this->validate($input);
         $container = $this->container = new Container($input->getOptions());
 
         /**
@@ -561,7 +561,7 @@ class Humbug extends Command
         ;
     }
 
-    protected function validate(InputInterface $input, OutputInterface $output)
+    private function validate(InputInterface $input)
     {
         /**
          * Adapter

--- a/src/Humbug/Command/Humbug.php
+++ b/src/Humbug/Command/Humbug.php
@@ -74,7 +74,7 @@ class Humbug extends Command
         /**
          * Log buffered renderer output to file if enabled
          */
-        $this->logText($input, $renderer);
+        $this->logText($renderer);
 
         /**
          * Make initial test run to ensure tests are in a starting passing state
@@ -123,7 +123,7 @@ class Humbug extends Command
          */
         if ($exitCode !== 0 || $hasFailure) {
             $renderer->renderInitialRunFail($result, $exitCode, $hasFailure);
-            $this->logText($input, $renderer);
+            $this->logText($renderer);
             exit(1);
         }
 
@@ -132,7 +132,7 @@ class Humbug extends Command
          */
         $renderer->renderInitialRunPass($result);
         $output->write(PHP_EOL);
-        $this->logText($input, $renderer);
+        $this->logText($renderer);
 
         /**
          * Analyse initial run logs to optimise future test runs by ordering
@@ -161,7 +161,7 @@ class Humbug extends Command
         $renderer->renderMutationTestingStart(count($mutables));
         $output->write(PHP_EOL);
         Performance::start();
-        $this->logText($input, $renderer);
+        $this->logText($renderer);
 
         /**
          * Iterate across all mutations. After each, run the test suite and
@@ -269,7 +269,7 @@ class Humbug extends Command
                     $countMutants++;
 
                     $renderer->renderProgressMark($result, count($mutables), $i);
-                    $this->logText($input, $renderer);
+                    $this->logText($renderer);
 
                     if ($result['timeout'] === true) {
                         $countMutantTimeouts++;
@@ -326,7 +326,7 @@ class Humbug extends Command
         }
         if ($this->logText === true) {
             $renderer->renderLogToText($this->textLogFile);
-            $this->logText($input, $renderer);
+            $this->logText($renderer);
             $out = [PHP_EOL, '-------', 'Escapes', '-------'];
             foreach ($mutantEscapes as $index => $escaped) {
                 $mutation = $escaped->getMutation();
@@ -362,7 +362,7 @@ class Humbug extends Command
                     $out[] = PHP_EOL;
                 }
             }
-            $this->logText($input, $renderer, implode(PHP_EOL, $out));
+            $this->logText($renderer, implode(PHP_EOL, $out));
         }
         if ($this->logJson === true || $this->logText === true) {
             $output->write(PHP_EOL);
@@ -372,7 +372,7 @@ class Humbug extends Command
          * Render performance data
          */
         $renderer->renderPerformanceData(Performance::getTimeString(), Performance::getMemoryUsageString());
-        $this->logText($input, $renderer);
+        $this->logText($renderer);
 
         Performance::downMemProfiler();
     }
@@ -584,22 +584,16 @@ class Humbug extends Command
         }
     }
 
-    protected function logText(InputInterface $input, Text $renderer, $output = null)
+    private function logText(Text $renderer, $output = null)
     {
         if ($this->logText === true) {
-            if (!is_null($output)) {
-                file_put_contents(
-                    $this->textLogFile,
-                    $output,
-                    FILE_APPEND
-                );
-            } else {
-                file_put_contents(
-                    $this->textLogFile,
-                    $renderer->getBuffer(),
-                    FILE_APPEND
-                );
-            }
+            $logText = !is_null($output) ? $output : $renderer->getBuffer();
+
+            file_put_contents(
+                $this->textLogFile,
+                $logText,
+                FILE_APPEND
+            );
         }
     }
 }

--- a/src/Humbug/Command/Humbug.php
+++ b/src/Humbug/Command/Humbug.php
@@ -54,7 +54,7 @@ class Humbug extends Command
         $output->writeln($this->getApplication()->getLongVersion() . PHP_EOL);
 
         $this->validate($input, $output);
-        $container = $this->container = new Container($input);
+        $container = $this->container = new Container($input->getOptions());
 
         /**
          * Setup source code finder and timeout if set

--- a/src/Humbug/Command/Humbug.php
+++ b/src/Humbug/Command/Humbug.php
@@ -54,7 +54,7 @@ class Humbug extends Command
         $output->writeln($this->getApplication()->getLongVersion() . PHP_EOL);
 
         $this->validate($input, $output);
-        $container = $this->container = new Container($input, $output);
+        $container = $this->container = new Container($input);
 
         /**
          * Setup source code finder and timeout if set

--- a/src/Humbug/Container.php
+++ b/src/Humbug/Container.php
@@ -12,15 +12,11 @@ namespace Humbug;
 
 use Humbug\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
 class Container
 {
-
     protected $input;
-
-    protected $output;
 
     protected $cache;
 
@@ -42,10 +38,9 @@ class Container
 
     protected $srcList;
 
-    public function __construct(InputInterface $input, OutputInterface $output)
+    public function __construct(InputInterface $input)
     {
         $this->input = $input;
-        $this->output = $output;
         $this->setAdapterOptionsFromString($this->input->getOption('options'));
     }
 

--- a/src/Humbug/Container.php
+++ b/src/Humbug/Container.php
@@ -11,12 +11,11 @@
 namespace Humbug;
 
 use Humbug\Exception\InvalidArgumentException;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Finder\Finder;
 
 class Container
 {
-    protected $input;
+    private $inputOptions;
 
     protected $cache;
 
@@ -38,10 +37,10 @@ class Container
 
     protected $srcList;
 
-    public function __construct(InputInterface $input)
+    public function __construct(array $inputOptions)
     {
-        $this->input = $input;
-        $this->setAdapterOptionsFromString($this->input->getOption('options'));
+        $this->inputOptions = $inputOptions;
+        $this->setAdapterOptionsFromString($this->inputOptions['options']);
     }
 
     /**
@@ -52,7 +51,11 @@ class Container
      */
     public function get($option)
     {
-        return $this->input->getOption($option);
+        if (!array_key_exists($option, $this->inputOptions)) {
+            throw new \InvalidArgumentException('Option "'. $option . ' not exists');
+        }
+
+        return $this->inputOptions[$option];
     }
 
     /**

--- a/src/Humbug/Generator.php
+++ b/src/Humbug/Generator.php
@@ -30,15 +30,12 @@ class Generator
      *
      * @return void
      */
-    public function generate(Finder $finder, $mutableObject = null)
+    public function generate(Finder $finder)
     {
         foreach ($finder as $file) {
-            if (is_null($mutableObject)) {
-                $mutable = new Mutable($file->getRealpath());
-            } else {
-                $mutable = new $mutableObject;
-                $mutable->setFilename($file->getRealpath());
-            }
+
+            $mutable = new Mutable($file->getRealpath());
+
             $this->mutables[] = $mutable;
         }
     }

--- a/tests/Humbug/Test/ContainerTest.php
+++ b/tests/Humbug/Test/ContainerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Humbug
+ *
+ * @category   Humbug
+ * @package    Humbug
+ * @copyright  Copyright (c) 2015 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    https://github.com/padraic/humbug/blob/master/LICENSE New BSD License
+ *
+ * @author     rafal.wartalski@gmail.com
+ */
+
+namespace Humbug\Test;
+
+use Humbug\Container;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
+class ContainerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testShouldHaveAdapterOptionsAfterCreate()
+    {
+        $input = $this->createInputMock();
+
+        $container = new Container($input);
+
+        $this->assertSame(['adapterOpt1', 'adapterOpt2'], $container->getAdapterOptions());
+    }
+
+    private function createInputMock()
+    {
+        $input = $this->getMock('\Symfony\Component\Console\Input\InputInterface');
+
+        $input->expects($this->at(0))->method('getOption')->with('options')->willReturn('adapterOpt1 adapterOpt2');
+
+        return $input;
+    }
+
+    public function testGetShouldReturnInputOption()
+    {
+        $input = $this->createInputMock();
+
+        $input->expects($this->at(1))->method('getOption')->with('test')->willReturn('test-option');
+
+        $container = new Container($input);
+
+        $this->assertSame('test-option', $container->get('test'));
+    }
+
+    public function testGetShouldRiseExceptionForUnknownOption()
+    {
+        $input = new ArgvInput([], new InputDefinition([new InputOption('options')]));
+
+        $this->setExpectedException('\InvalidArgumentException');
+
+        $container = new Container($input);
+
+        $container->get('invalid-option');
+    }
+
+}

--- a/tests/Humbug/Test/ContainerTest.php
+++ b/tests/Humbug/Test/ContainerTest.php
@@ -23,7 +23,9 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldHaveAdapterOptionsAfterCreate()
     {
-        $input = $this->createInputMock();
+        $input = [
+            'options' => 'adapterOpt1 adapterOpt2'
+        ];
 
         $container = new Container($input);
 
@@ -41,9 +43,10 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetShouldReturnInputOption()
     {
-        $input = $this->createInputMock();
-
-        $input->expects($this->at(1))->method('getOption')->with('test')->willReturn('test-option');
+        $input = [
+            'options' => 'adapterOpt1 adapterOpt2',
+            'test' => 'test-option'
+        ];
 
         $container = new Container($input);
 
@@ -52,7 +55,9 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetShouldRiseExceptionForUnknownOption()
     {
-        $input = new ArgvInput([], new InputDefinition([new InputOption('options')]));
+        $input = [
+            'options' => null
+        ];
 
         $this->setExpectedException('\InvalidArgumentException');
 

--- a/tests/Humbug/Test/GeneratorTest.php
+++ b/tests/Humbug/Test/GeneratorTest.php
@@ -52,27 +52,6 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($mutables[1]->getFilename(), $this->searchDir . '/library/bool2.php');
     }
 
-    public function testShouldGenerateMutableFileObjects()
-    {
-        $generator = new Generator;
-        $mutable = m::mock('\\Humbug\\Mutable[]');
-
-        $generator->generate($this->finder, $mutable);
-        $mutables = $generator->getMutables();
-
-        $this->assertTrue($mutables[0] instanceof Mutable);
-    }
-
-    public function testShouldGenerateAMutableFileObjectPerDetectedFile()
-    {
-        $generator = new Generator;
-
-        $mutable = $this->getMock('Mutable', ['setFilename']);
-
-        $generator->generate($this->finder, $mutable);
-        $this->assertEquals(2, count($generator->getMutables()));
-    }
-
     private function createPhpFileFinder($searchDir)
     {
         $finder = new Finder;


### PR DESCRIPTION
A little refactoring with some code cleanups.
Main changes:
* Generator::generate method does not accept second parameter - it was never used in codebase
* Container does not depends on InputInterface anymore - Container is using only options so there is no need to pass all input into it. Did some exploration test there.