### PR TITLE
Change the way to return a failure exit code in the command

### DIFF
--- a/src/Humbug/Command/Humbug.php
+++ b/src/Humbug/Command/Humbug.php
@@ -124,7 +124,8 @@ class Humbug extends Command
         if ($exitCode !== 0 || $hasFailure) {
             $renderer->renderInitialRunFail($result, $exitCode, $hasFailure);
             $this->logText($renderer);
-            exit(1);
+
+            return 1;
         }
 
         /**


### PR DESCRIPTION
Returning the exit code to the Symfony Application rather than exiting directly in the command gives more flexibility (you would be able to run tests for your command for instance, while it would be a pain when using ``exit``)