### PR TITLE
Add xdebug to the list of required dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "ext-xdebug": "*",
+        "ext-xdebug": "~2.2",
         "phpunit/phpunit": "~4.4",
         "symfony/console": "~2.6",
         "symfony/finder": "~2.6",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": ">=5.4.0",
+        "ext-xdebug": "*",
         "phpunit/phpunit": "~4.4",
         "symfony/console": "~2.6",
         "symfony/finder": "~2.6",


### PR DESCRIPTION
If xdebug is not installed, coverage file won't be generated and Humbug\Container will throw an InvalidArgumentException