### PR TITLE
Strip slashes to fix Windows issue.

### DIFF
--- a/src/Utility/CoverageData.php
+++ b/src/Utility/CoverageData.php
@@ -133,7 +133,7 @@ class CoverageData
                 if ($passthru === true) {
                     $this->wrapup($out);
                 }
-                $file = 'coverage.humbug.' . md5($matches[1]) . '.cache';
+                $file = 'coverage.humbug.' . md5(stripslashes($matches[1])) . '.cache';
                 $out = fopen(sys_get_temp_dir() . '/' . $file, 'w');
                 $buffer = '<?php'
                     . PHP_EOL . '$coverage = new PHP_CodeCoverage;'


### PR DESCRIPTION
This should make it possible to (finally) run Humbug on Windows. Currently it manages to detect line coverage just fine after the initial test run, but while running the actual mutation testing it marks every test with a S (uncovered).

I managed to track the issue down to the `coverage.humbug.[hash].cache` file, more specifically the name of the cache file. On Windows all the file paths' backslashes are escaped in the coverage report (coverage.humbug.php), so `C:\Path\To\My\File.php` would be `C:\\Path\\To\\My\\File.php` and this is the path being md5'd for the filename of the cache. To retrieve this cache file later the method `loadCoverageFor()` is called with a file path, this path however isn't escaped so the method would end up with a different hash and thus can't find the cache file.

Not sure if `stripslashes()` will end up removing other things in weird cases, but it felt like a cleaner solution than `str_replace('\\\\', '\\', $matches[1])`.
