### PR TITLE
XmlConfiguration fixed for wildcards in directoies

### DIFF
--- a/src/Adapter/AdapterAbstract.php
+++ b/src/Adapter/AdapterAbstract.php
@@ -68,9 +68,9 @@ abstract class AdapterAbstract
      */
     public function hasOks($output)
     {
-        $result = preg_match("%ok (\\d+) - .*$%", $output, $matches);
+        $result = preg_match_all("%ok (\\d+) - .*%m", $output, $matches);
         if ($result) {
-            return (int) $matches[1];
+            return (int) end($matches[1]);
         }
         return false;
     }

--- a/src/Adapter/Locator.php
+++ b/src/Adapter/Locator.php
@@ -43,4 +43,11 @@ class Locator
 
         throw new InvalidArgumentException("Could not find file $name working from $this->workingDir");
     }
+
+    public function locateDirectories($name)
+    {
+        $glob = glob($this->workingDir . '/' . $name, GLOB_ONLYDIR);
+
+        return array_map([$this, 'locate'], $glob);
+    }
 }

--- a/src/Adapter/Phpunit/XmlConfiguration.php
+++ b/src/Adapter/Phpunit/XmlConfiguration.php
@@ -175,7 +175,7 @@ class XmlConfiguration
         }
     }
 
-    public function replacePathsToAbsolutePaths(Visitor $visitor)
+    public function replacePathsToAbsolutePaths(Visitor $pathVisitor, Visitor $wildcardVisitor)
     {
         $replacePaths = [
             '/phpunit/testsuites/testsuite/exclude',
@@ -188,8 +188,12 @@ class XmlConfiguration
 
         $replaceNodes = $this->xpath->query($replaceQuery);
 
-        foreach ($replaceNodes as $exclude) {
-            $visitor->visitElement($exclude);
+        foreach ($replaceNodes as $replace) {
+            if (false !== strpos($replace->nodeValue, '*')) {
+                $wildcardVisitor->visitElement($replace);
+            } else {
+                $pathVisitor->visitElement($replace);
+            }
         }
     }
 

--- a/src/Adapter/Phpunit/XmlConfiguration/ReplaceWildcardVisitor.php
+++ b/src/Adapter/Phpunit/XmlConfiguration/ReplaceWildcardVisitor.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Humbug\Adapter\Phpunit\XmlConfiguration;
+
+use Humbug\Adapter\Locator;
+
+class ReplaceWildcardVisitor implements Visitor
+{
+    /**
+     * @var Locator
+     */
+    private $locator;
+
+    public function __construct(Locator $locator)
+    {
+        $this->locator = $locator;
+    }
+
+    public function visitElement(\DOMNode $domElement)
+    {
+        $directories = $this->locator->locateDirectories($domElement->nodeValue);
+
+        $domDocument = $domElement->ownerDocument;
+
+        $parentNode = $domElement->parentNode;
+        $domElement->parentNode->removeChild($domElement);
+
+        foreach ($directories as $directory) {
+            $parentNode->appendChild($domDocument->createElement($domElement->tagName, $directory));
+        }
+    }
+}

--- a/src/Adapter/Phpunit/XmlConfigurationBuilder.php
+++ b/src/Adapter/Phpunit/XmlConfigurationBuilder.php
@@ -15,6 +15,7 @@ namespace Humbug\Adapter\Phpunit;
 use Humbug\Adapter\Locator;
 use Humbug\Adapter\Phpunit\XmlConfiguration\ObjectVisitor;
 use Humbug\Adapter\Phpunit\XmlConfiguration\ReplacePathVisitor;
+use Humbug\Adapter\Phpunit\XmlConfiguration\ReplaceWildcardVisitor;
 
 class XmlConfigurationBuilder
 {
@@ -122,8 +123,11 @@ class XmlConfigurationBuilder
      */
     private function initializeConfiguration(XmlConfiguration $xmlConfiguration)
     {
-        $replacePathVisitor = new ReplacePathVisitor(new Locator($this->configurationDir));
-        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor);
+        $locator = new Locator($this->configurationDir);
+
+        $replacePathVisitor = new ReplacePathVisitor($locator);
+        $replaceWildcardVisitor = new ReplaceWildcardVisitor($locator);
+        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor, $replaceWildcardVisitor);
 
         $xmlConfiguration->setBootstrap($this->getNewBootstrapPath());
         $xmlConfiguration->turnOffCacheTokens();

--- a/tests/Adapter/LocatorTest.php
+++ b/tests/Adapter/LocatorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Humbug\Test\Adapter;
+
+use Humbug\Adapter\Locator;
+
+class LocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldLocateMany()
+    {
+        $dir = __DIR__ . '/../Adapter/_files';
+
+        $locator = new Locator($dir);
+
+        $actual = $locator->locateDirectories('php*');
+
+        $expected = [
+            realpath($dir . '/phpunit'),
+            realpath($dir . '/phpunit-conf'),
+            realpath($dir . '/phpunit2'),
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+} 

--- a/tests/Adapter/Phpunit/XmlConfiguration/ReplaceWildcardVisitorTest.php
+++ b/tests/Adapter/Phpunit/XmlConfiguration/ReplaceWildcardVisitorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Humbug
+ *
+ * @category   Humbug
+ * @package    Humbug
+ * @copyright  Copyright (c) 2015 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    https://github.com/padraic/humbug/blob/master/LICENSE New BSD License
+ *
+ * @author     rafal.wartalski@gmail.com
+ */
+
+namespace Humbug\Test\Adapter\Phpunit\XmlConfiguration;
+
+use Humbug\Adapter\Locator;
+use Humbug\Adapter\Phpunit\XmlConfiguration\ReplaceWildcardVisitor;
+
+class ReplaceWildcardVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ReplaceWildcardVisitor
+     */
+    private $replaceWildcardVisitor;
+
+    /**
+     * @var string
+     */
+    private $wildcardDir;
+
+    protected function setUp()
+    {
+        $this->wildcardDir = __DIR__ . '/../../_files/regression/wildcard-dirs';
+
+        $this->replaceWildcardVisitor = new ReplaceWildcardVisitor(new Locator($this->wildcardDir));
+    }
+
+    public function testShouldBeVisitor()
+    {
+        $this->assertInstanceOf('Humbug\Adapter\Phpunit\XmlConfiguration\Visitor', $this->replaceWildcardVisitor);
+    }
+
+    public function testShouldReplaceWildcardWithOneRealPath()
+    {
+        $dom = new \DOMDocument();
+        $visitedObject = $dom->createElement('object', '*suite');
+        $dom->appendChild($visitedObject);
+
+        $this->replaceWildcardVisitor->visitElement($visitedObject);
+
+        $xpath = new \DOMXPath($dom);
+
+        $expected = realpath($this->wildcardDir . '/second-suite');
+
+        $this->assertEquals($expected, $xpath->query('/object')->item(0)->nodeValue);
+    }
+
+    public function testShouldReplaceWildcardWithManyRealPaths()
+    {
+        $dom = new \DOMDocument();
+        $visitedObject = $dom->createElement('object', '*/Tests');
+        $dom->appendChild($visitedObject);
+
+        $this->replaceWildcardVisitor->visitElement($visitedObject);
+        $xpath = new \DOMXPath($dom);
+
+        $secondExpected = realpath($this->wildcardDir . '/second-suite/Tests');
+        $firstExpected = realpath($this->wildcardDir . '/suite-first/Tests');
+
+        $this->assertEquals(1, $xpath->query('/object[text()="' . $secondExpected .'"]')->length);
+        $this->assertEquals(1, $xpath->query('/object[text()="' . $firstExpected .'"]')->length);
+    }
+}

--- a/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
+++ b/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
@@ -51,9 +51,10 @@ class XmlConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('false', $cacheTokens->item(0)->nodeValue);
         $this->assertEquals(0, $xpath->evaluate('count(/phpunit/logging|/phpunit/filter|/phpunit/listeners)'));
 
-        $expectedVisitor = new XmlConfiguration\ReplacePathVisitor(new Locator($this->configurationDir));
+        $expectedPathVisitor = new XmlConfiguration\ReplacePathVisitor(new Locator($this->configurationDir));
+        $expectedWildcardVisitor = new XmlConfiguration\ReplaceWildcardVisitor(new Locator($this->configurationDir));
 
-        $xmlConfiguration->wasCalledWith('replacePathsToAbsolutePaths', [$expectedVisitor], 0);
+        $xmlConfiguration->wasCalledWith('replacePathsToAbsolutePaths', [$expectedPathVisitor, $expectedWildcardVisitor], 0);
     }
 
     public function testShouldBuildConfigurationWithAcceleratorListener()
@@ -163,7 +164,7 @@ class FakeConfiguration extends XmlConfiguration
         $this->calls[][__FUNCTION__] = func_get_args();
     }
 
-    public function replacePathsToAbsolutePaths(XmlConfiguration\Visitor $visitor)
+    public function replacePathsToAbsolutePaths(XmlConfiguration\Visitor $pathVisitor, XmlConfiguration\Visitor $wildcardVisitor)
     {
         $this->calls[][__FUNCTION__] = func_get_args();
     }

--- a/tests/Adapter/Phpunit/XmlConfigurationTest.php
+++ b/tests/Adapter/Phpunit/XmlConfigurationTest.php
@@ -313,9 +313,11 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $xmlConfiguration = new XmlConfiguration($dom);
 
-        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor(new Locator($configurationDir));
+        $locator = new Locator($configurationDir);
+        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor($locator);
+        $replaceWildCardVisitor = new XmlConfiguration\ReplaceWildcardVisitor($locator);
 
-        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor);
+        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor, $replaceWildCardVisitor);
 
         $xpath = new \DOMXPath($dom);
 
@@ -337,9 +339,11 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $xmlConfiguration = new XmlConfiguration($dom);
 
-        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor(new Locator($configurationDir));
+        $locator = new Locator($configurationDir);
+        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor($locator);
+        $replaceWildCardVisitor = new XmlConfiguration\ReplaceWildcardVisitor($locator);
 
-        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor);
+        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor, $replaceWildCardVisitor);
 
         $xpath = new \DOMXPath($dom);
 
@@ -354,9 +358,11 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $xmlConfiguration = new XmlConfiguration($dom);
 
-        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor(new Locator($configurationDir));
+        $locator = new Locator($configurationDir);
+        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor($locator);
+        $replaceWildCardVisitor = new XmlConfiguration\ReplaceWildcardVisitor($locator);
 
-        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor);
+        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor, $replaceWildCardVisitor);
 
         $xpath = new \DOMXPath($dom);
 
@@ -371,14 +377,43 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $xmlConfiguration = new XmlConfiguration($dom);
 
-        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor(new Locator($configurationDir));
+        $locator = new Locator($configurationDir);
+        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor($locator);
+        $replaceWildCardVisitor = new XmlConfiguration\ReplaceWildcardVisitor($locator);
 
-        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor);
+        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor, $replaceWildCardVisitor);
 
         $xpath = new \DOMXPath($dom);
 
         $actualBootstrapPath = $xpath->query('/phpunit/@bootstrap')->item(0)->nodeValue;
         $this->assertEquals($configurationDir . '/file.php', $actualBootstrapPath);
+    }
+
+    public function testShouldReplaceWildcardsWithAbsolutePaths()
+    {
+        $configurationDir = realpath(__DIR__ . '/../_files/regression/wildcard-dirs');
+        $dom = (new ConfigurationLoader())->load($configurationDir . '/phpunit.xml');
+
+        $xmlConfiguration = new XmlConfiguration($dom);
+
+        $locator = new Locator($configurationDir);
+
+        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor($locator);
+        $replaceWildCardVisitor = new XmlConfiguration\ReplaceWildcardVisitor($locator);
+
+        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor, $replaceWildCardVisitor);
+
+        $xpath = new \DOMXPath($dom);
+
+        $firstSuitePath = realpath($configurationDir . '/suite-first/Tests');
+        $firstReplaced = $xpath->query('/phpunit/testsuites/testsuite[@name="Test Suite"]/directory[text()="' . $firstSuitePath . '"]');
+
+        $this->assertEquals(1, $firstReplaced->length);
+
+        $secondSuitePath = realpath($configurationDir . '/second-suite/Tests');
+        $secondReplaced = $xpath->query('/phpunit/testsuites/testsuite[@name="Test Suite"]/directory[text()="' . $secondSuitePath . '"]');
+
+        $this->assertEquals(1, $secondReplaced->length);
     }
 
     public function testShouldNotReplaceBootstrapWithAbsolutePath()
@@ -391,9 +426,11 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $xmlConfiguration = new XmlConfiguration($dom);
 
-        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor(new Locator($configurationDir));
+        $locator = new Locator($configurationDir);
+        $replacePathVisitor = new XmlConfiguration\ReplacePathVisitor($locator);
+        $replaceWildCardVisitor = new XmlConfiguration\ReplaceWildcardVisitor($locator);
 
-        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor);
+        $xmlConfiguration->replacePathsToAbsolutePaths($replacePathVisitor, $replaceWildCardVisitor);
 
         $actualBootstrapPath = $xpath->query('/phpunit/@bootstrap');
         $this->assertEquals(0, $actualBootstrapPath->length);

--- a/tests/Adapter/PhpunitTest.php
+++ b/tests/Adapter/PhpunitTest.php
@@ -240,4 +240,35 @@ not ok 103 - Error: Humbug\Test\Utility\TestTimeAnalyserTest::testAnalysisOfJuni
 OUTPUT;
         $this->assertFalse($adapter->ok($output));
     }
+
+    public function testShouldNotNotifyRegressionWhileRunningProcess()
+    {
+        $directory = __DIR__ . '/_files/regression/wildcard-dirs';
+
+        $container = m::mock('\Humbug\Container');
+        $container->shouldReceive([
+            'getSourceList'    => $directory,
+            'getTestRunDirectory'   => $directory,
+            'getBaseDirectory'      => $directory,
+            'getTimeout'            => 1200,
+            'getCacheDirectory'     => $this->tmpDir,
+            'getAdapterOptions'     => [],
+            'getBootstrap'          => '',
+            'getAdapterConstraints' => ''
+        ]);
+
+        $adapter = new Phpunit;
+        $process = $adapter->getProcess(
+            $container,
+            true,
+            true
+        );
+        $process->run();
+
+        $result = $process->getOutput();
+
+        $this->assertEquals(2, $adapter->hasOks($result));
+        $this->assertStringStartsWith('TAP version', $result);
+        $this->assertTrue($adapter->ok($result), "Regression output: \n" . $result);
+    }
 }

--- a/tests/Adapter/_files/regression/wildcard-dirs/phpunit.xml
+++ b/tests/Adapter/_files/regression/wildcard-dirs/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.4/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false">
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./*/Tests</directory>
+        </testsuite>
+    </testsuites>
+    
+</phpunit>

--- a/tests/Adapter/_files/regression/wildcard-dirs/second-suite/Tests/SecondTest.php
+++ b/tests/Adapter/_files/regression/wildcard-dirs/second-suite/Tests/SecondTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class SecondTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSecond()
+    {
+
+    }
+} 

--- a/tests/Adapter/_files/regression/wildcard-dirs/suite-first/Tests/FirstTest.php
+++ b/tests/Adapter/_files/regression/wildcard-dirs/suite-first/Tests/FirstTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class FirstTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFirst()
+    {
+
+    }
+} 


### PR DESCRIPTION
After #104 replacement for wildcard directories in phpunit.xml disapeard.
It fixes this issue. And it will fix #110 with 90% sure.