### PR TITLE
Humbug should work with relative chdir

### DIFF
--- a/src/Adapter/Phpunit.php
+++ b/src/Adapter/Phpunit.php
@@ -233,7 +233,7 @@ class Phpunit extends AdapterAbstract
             $configurationDir = $container->getBaseDirectory();
         }
 
-        return $configurationDir;
+        return realpath($configurationDir);
     }
 
     /**

--- a/tests/Adapter/PhpunitTest.php
+++ b/tests/Adapter/PhpunitTest.php
@@ -241,10 +241,11 @@ OUTPUT;
         $this->assertFalse($adapter->ok($output));
     }
 
-    public function testShouldNotNotifyRegressionWhileRunningProcess()
+    /**
+     * @dataProvider directoriesList
+     */
+    public function testShouldNotNotifyRegressionWhileRunningProcess($directory)
     {
-        $directory = __DIR__ . '/_files/regression/wildcard-dirs';
-
         $container = m::mock('\Humbug\Container');
         $container->shouldReceive([
             'getSourceList'    => $directory,
@@ -270,5 +271,13 @@ OUTPUT;
         $this->assertEquals(2, $adapter->hasOks($result));
         $this->assertStringStartsWith('TAP version', $result);
         $this->assertTrue($adapter->ok($result), "Regression output: \n" . $result);
+    }
+
+    public function directoriesList()
+    {
+        return [
+            [__DIR__ . '/_files/regression/wildcard-dirs'],
+            ['tests/Adapter/_files/regression/wildcard-dirs']
+        ];
     }
 }


### PR DESCRIPTION
Main cause of #110 was that there was a problem with searching for testsuites ditecories to relative path given with chrdir.