### PR TITLE
Return relative file path in Mutant::toArray

### DIFF
--- a/src/Mutant.php
+++ b/src/Mutant.php
@@ -136,7 +136,7 @@ class Mutant
     public function toArray()
     {
         return [
-            'file' => $this->mutation['file'],
+            'file' => $this->getMutationFileRelativePath(),
             'mutator' => $this->mutation['mutator'],
             'class' => $this->mutation['class'],
             'method' => $this->mutation['method'],
@@ -146,5 +146,13 @@ class Mutant
             'stderr' => $this->getProcess()->getErrorOutput(),
             'tests' => $this->getTests()
         ];
+    }
+
+    private function getMutationFileRelativePath()
+    {
+        $path = explode(DIRECTORY_SEPARATOR, $this->mutation['file']);
+        $baseDirectory = explode(DIRECTORY_SEPARATOR, $this->container->getBaseDirectory());
+
+        return join(DIRECTORY_SEPARATOR, array_diff($path, $baseDirectory));
     }
 }


### PR DESCRIPTION
Changes the path of the file affected by a mutant in the JSON log file to be relative to the root of the project, as it makes it more complicated to parse the log on a different machine than the one where the mutation tests were run.

This P/R does not affect text logs.