### PR TITLE
Prepare humbug to have more than 1 command in it

### DIFF
--- a/bin/humbug
+++ b/bin/humbug
@@ -20,4 +20,31 @@ if (function_exists('ini_set')) {
 }
 
 $application = new Application();
-$application->run();
+$application->add(new \Humbug\Command\Configure());
+$application->add(new \Humbug\Command\Humbug());
+
+if ('phar:' === substr(__FILE__, 0, 5)) {
+    $application->add(new \Humbug\Command\SelfUpdate());
+}
+
+function prepareArgv()
+{
+    $argv = $_SERVER['argv'];
+
+    $found = false;
+
+    while (next($argv)) {
+        $value = current($argv);
+        if (!$value || '-' !== $value[0]) {
+            $found = true;
+        }
+    }
+
+    if (!$found) {
+        $argv[] = 'run';
+    }
+
+    return $argv;
+}
+
+$application->run(new \Symfony\Component\Console\Input\ArgvInput(prepareArgv()));

--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -55,16 +55,6 @@ class Humbug extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /**
-         * Humbug is a single command app. We run secondary commands indirectly.
-         * Currently self-update is the only one necessary.
-         */
-        if ($input->getArgument('subcommand') == 'self-update') {
-            $command = $this->getApplication()->find('self-update');
-            $noinput = new EmptyInput([]);
-            return $command->run($noinput, $output);
-        }
-
         Performance::upMemProfiler();
         $output->writeln($this->getApplication()->getLongVersion() . PHP_EOL);
 
@@ -409,7 +399,7 @@ class Humbug extends Command
     protected function configure()
     {
         $this
-            ->setName('humbug')
+            ->setName('run')
             ->setDescription('Run Humbug for target tests')
             ->addOption(
                'adapter',
@@ -438,14 +428,7 @@ class Humbug extends Command
                InputOption::VALUE_REQUIRED,
                'Sets a timeout applied for each test run to combat infinite loop mutations.',
                 10
-            )
-            ->addArgument(
-                'subcommand',
-                InputArgument::OPTIONAL,
-                'Run a secondary command, typically self-update!',
-                null
-            )
-        ;
+            );
     }
 
     private function validate(InputInterface $input)

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -11,13 +11,9 @@
 namespace Humbug\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
-use Symfony\Component\Console\Input\InputInterface;
-use Humbug\Command\Humbug;
-use Humbug\Command\SelfUpdate;
 
 class Application extends BaseApplication
 {
-
     private static $logo = '
  _  _            _
 | || |_  _ _ __ | |__ _  _ __ _
@@ -32,27 +28,5 @@ class Application extends BaseApplication
     public function __construct()
     {
         parent::__construct(self::$logo.PHP_EOL.self::NAME, self::VERSION);
-    }
-
-    public function getDefinition()
-    {
-        $inputDefinition = parent::getDefinition();
-        $inputDefinition->setArguments();
-        return $inputDefinition;
-    }
-
-    protected function getCommandName(InputInterface $input)
-    {
-        return 'humbug';
-    }
-
-    protected function getDefaultCommands()
-    {
-        $defaultCommands = parent::getDefaultCommands();
-        $defaultCommands[] = new Humbug();
-        if ('phar:' === substr(__FILE__, 0, 5)) {
-            $defaultCommands[] = new SelfUpdate();
-        }
-        return $defaultCommands;
     }
 }


### PR DESCRIPTION
As self-update was next command in humbug it may me executed as command. Subcommand approach does not fit here IMO.

Running `humbug` still works by setting default command in bin/humbug if it was not set.

