### PR TITLE
Correctly detect reference operator when wrapped in whitespace

### DIFF
--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -30,17 +30,18 @@ class BitwiseAnd extends MutatorAbstract
     public static function mutates(array &$tokens, $index)
     {
         $t = $tokens[$index];
+
         if (!is_array($t) && $t == '&') {
             /**
              * Exclude likely uses of ampersand for references
              */
-            if (isset($tokens[$index+1]) && is_array($tokens[$index+1]) && $tokens[$index+1][0] == T_VARIABLE) {
+            if (self::getNextToken($tokens, $index, [ T_WHITESPACE ]) === T_VARIABLE) {
                 return false;
             }
-            if (isset($tokens[$index+1]) && is_array($tokens[$index+1]) && $tokens[$index+1][0] == T_FUNCTION) {
+            if (self::getNextToken($tokens, $index, [ T_WHITESPACE ]) === T_FUNCTION) {
                 return false;
             }
-            if (isset($tokens[$index-1]) && !is_array($tokens[$index-1]) && $tokens[$index-1] == '=') {
+            if (self::getPreviousToken($tokens, $index, [ T_WHITESPACE ]) === '=') {
                 return false;
             }
             return true;

--- a/src/Mutator/MutatorAbstract.php
+++ b/src/Mutator/MutatorAbstract.php
@@ -27,4 +27,56 @@ abstract class MutatorAbstract
         static::getMutation($tokens, $index);
         return Tokenizer::reconstructFromTokens($tokens);
     }
+
+    private static function shouldSkip($token, array $excludeTokens)
+    {
+        if (! is_array($token) && in_array($token, $excludeTokens, true)) {
+            return true;
+        }
+
+        return in_array($token[0], $excludeTokens, true);
+    }
+
+    /**
+     * Finds the next token in token array after a given index.
+     * @param array $tokens Token array to lookup
+     * @param int $index Position to start lookup at
+     * @param array $excludeTokens Excluded tokens list
+     *
+     * @return int|string|false The next match if found, or false. Token is guaranteed to be a scalar if a match is found.
+     */
+    protected static function getNextToken(array $tokens, $index, array $excludeTokens = [])
+    {
+        while ($index < count($tokens) && isset($tokens[$index+1]) && self::shouldSkip($tokens[$index + 1], $excludeTokens)) {
+            $index++;
+        }
+
+        if (! isset($tokens[$index+1])) {
+            return false;
+        }
+
+        return is_array($tokens[$index+1]) ? $tokens[$index+1][0] : $tokens[$index+1];
+    }
+
+
+    /**
+     * Finds the next token value in token array before a given index.
+     * @param array $tokens Token array to lookup
+     * @param int $index Position to start lookup at
+     * @param array $excludeTokens Excluded tokens list
+     *
+     * @return int|string|false The previous match if found, or false. Token is guaranteed to be a scalar if a match is found.
+     */
+    protected static function getPreviousToken(array $tokens, $index, array $excludeTokens = [])
+    {
+        while ($index > 0 && isset($tokens[$index-1]) && self::shouldSkip($tokens[$index - 1], $excludeTokens)) {
+            $index--;
+        }
+
+        if (! isset($tokens[$index-1])) {
+            return false;
+        }
+
+        return is_array($tokens[$index-1]) ? $tokens[$index-1][0] : $tokens[$index-1];
+    }
 }

--- a/tests/Mutator/Arithmetic/BitwiseAndTest.php
+++ b/tests/Mutator/Arithmetic/BitwiseAndTest.php
@@ -34,4 +34,24 @@ class BitwiseAndTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(Mutator\Arithmetic\BitwiseAnd::mutates($tokens, 11));
     }
+
+    public function getByRefContexts()
+    {
+        return [
+            [ [ '=', T_WHITESPACE, '&', T_FUNCTION ], 2 ],
+            [ [ '=', T_WHITESPACE, T_WHITESPACE, '&', T_FUNCTION ], 3 ],
+            [ [ '=', T_WHITESPACE, '&', T_WHITESPACE, T_FUNCTION ], 2 ],
+            [ [ '=', '&', T_WHITESPACE, T_FUNCTION ], 1 ],
+            [ [ '=', '&', T_WHITESPACE, T_WHITESPACE, T_FUNCTION ], 1 ],
+
+        ];
+    }
+
+    /**
+     * @dataProvider getByRefContexts
+     */
+    public function testDoesNotMutateByRefAssignments(array $tokens, $index)
+    {
+        $this->assertFalse(Mutator\Arithmetic\BitwiseAnd::mutates($tokens, $index));
+    }
 }


### PR DESCRIPTION
Fix for #119 