### PR TITLE
fixes failing tests due to DIRECTORY_SEPARATOR issues

### DIFF
--- a/tests/Adapter/Phpunit/XmlConfigurationTest.php
+++ b/tests/Adapter/Phpunit/XmlConfigurationTest.php
@@ -325,11 +325,11 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($configurationDir, $actualSuiteDirectory);
 
         $actualWhiteListDirectory = $xpath->query('/phpunit/filter/whitelist/directory')->item(0)->nodeValue;
-        $this->assertEquals($configurationDir . '/white-list', $actualWhiteListDirectory);
+        $this->assertEquals($configurationDir . DIRECTORY_SEPARATOR . 'white-list', $actualWhiteListDirectory);
 
         $actualWhiteListExcludeDirectory =
             $xpath->query('/phpunit/filter/whitelist/exclude/directory')->item(0)->nodeValue;
-        $this->assertEquals($configurationDir . '/white-list/exclude', $actualWhiteListExcludeDirectory);
+        $this->assertEquals($configurationDir . DIRECTORY_SEPARATOR . 'white-list' . DIRECTORY_SEPARATOR . 'exclude', $actualWhiteListExcludeDirectory);
     }
 
     public function testShouldReplaceFilePathsToAbsolutePaths()
@@ -348,7 +348,7 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
         $xpath = new \DOMXPath($dom);
 
         $actualSuiteDirectory = $xpath->query('/phpunit/testsuites/testsuite/file')->item(0)->nodeValue;
-        $this->assertEquals($configurationDir . '/file.php', $actualSuiteDirectory);
+        $this->assertEquals($configurationDir . DIRECTORY_SEPARATOR . 'file.php', $actualSuiteDirectory);
     }
 
     public function testShouldReplaceSuiteExcludesWithAbsolutePaths()
@@ -367,7 +367,7 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
         $xpath = new \DOMXPath($dom);
 
         $actualSuiteExclude = $xpath->query('/phpunit/testsuites/testsuite/exclude')->item(0)->nodeValue;
-        $this->assertEquals($configurationDir . '/excluded-tests', $actualSuiteExclude);
+        $this->assertEquals($configurationDir . DIRECTORY_SEPARATOR . 'excluded-tests', $actualSuiteExclude);
     }
 
     public function testShouldReplaceBootstrapWithAbsolutePath()
@@ -386,7 +386,7 @@ class XmlConfigurationTest extends \PHPUnit_Framework_TestCase
         $xpath = new \DOMXPath($dom);
 
         $actualBootstrapPath = $xpath->query('/phpunit/@bootstrap')->item(0)->nodeValue;
-        $this->assertEquals($configurationDir . '/file.php', $actualBootstrapPath);
+        $this->assertEquals($configurationDir . DIRECTORY_SEPARATOR . 'file.php', $actualBootstrapPath);
     }
 
     public function testShouldReplaceWildcardsWithAbsolutePaths()

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -30,7 +30,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->searchDir = dirname(__FILE__) . '/_files/root/base1';
+        $this->searchDir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'root' . DIRECTORY_SEPARATOR . 'base1';
 
         $this->finder = $this->createPhpFileFinder($this->searchDir);
     }
@@ -48,8 +48,8 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $generator->generate($this->finder);
         $mutables = $generator->getMutables();
 
-        $this->assertEquals($mutables[0]->getFilename(), $this->searchDir . '/library/bool1.php');
-        $this->assertEquals($mutables[1]->getFilename(), $this->searchDir . '/library/bool2.php');
+        $this->assertEquals($mutables[0]->getFilename(), $this->searchDir . DIRECTORY_SEPARATOR . 'library' . DIRECTORY_SEPARATOR . 'bool1.php');
+        $this->assertEquals($mutables[1]->getFilename(), $this->searchDir . DIRECTORY_SEPARATOR . 'library' . DIRECTORY_SEPARATOR . 'bool2.php');
     }
 
     private function createPhpFileFinder($searchDir)

--- a/tests/MutantTest.php
+++ b/tests/MutantTest.php
@@ -143,7 +143,7 @@ class MutantTest extends \PHPUnit_Framework_TestCase
     public function getMutation()
     {
         return new Mutation(
-            __DIR__ . '/_files/mutables/Math.php',
+            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'mutables' . DIRECTORY_SEPARATOR . 'Math.php',
             8,
             'Phpunit_MM1_Math',
             'add',
@@ -159,7 +159,7 @@ class MutantTest extends \PHPUnit_Framework_TestCase
             $mutation,
             $this->getFileGenerator(),
             $this->getCoverageData([ 'dummy' ], [ 'dummyMethod' ]),
-            __DIR__ . '/_files/mutables/'
+            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'mutables' . DIRECTORY_SEPARATOR
         );
 
         $this->assertEquals($mutation, $mutant->getMutation());
@@ -173,7 +173,7 @@ class MutantTest extends \PHPUnit_Framework_TestCase
             $this->getMutation(),
             $this->getFileGenerator(),
             $this->getExceptionRaisingCoverageData(),
-            __DIR__ . '/_files/mutables/'
+            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'mutables' . DIRECTORY_SEPARATOR
         );
         $this->assertSame([], $mutant->getTests());
     }
@@ -185,7 +185,7 @@ class MutantTest extends \PHPUnit_Framework_TestCase
             $mutation,
             new FileGenerator(__DIR__ . '/_files/mutants/'),
             $this->getCoverageData([ 'dummy' ], [ 'dummyMethod' ]),
-            __DIR__ . '/_files/mutables/'
+            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'mutables' . DIRECTORY_SEPARATOR
         );
 
         $diff = $this->prophesize('Humbug\Utility\Diff');


### PR DESCRIPTION
When running `phpunit --coverage-text` several tests are failing on Windows due to directory separator  issues. This PR fixes this by replacing the hard-coded slashes with DIRECTORY_SEPARATOR in the tests.