### PR TITLE
Implemented command line configuration of log files

### DIFF
--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -185,8 +185,8 @@ class Humbug extends Command
         if ($chDir !== null) {
             $this->container->setTestRunDirectory($chDir);
         }
-        $this->jsonLogFile = $newConfig->getLogsJson();
-        $this->textLogFile = $newConfig->getLogsText();
+        $this->jsonLogFile = $input->getOption('log-json') ?: $newConfig->getLogsJson();
+        $this->textLogFile = $input->getOption('log-text') ?: $newConfig->getLogsText();
 
         $this->builder = new MutantBuilder();
         $this->builder->setLogFiles($this->textLogFile, $this->jsonLogFile);
@@ -250,6 +250,18 @@ class Humbug extends Command
                'i',
                InputOption::VALUE_NONE,
                'Enable incremental mutation testing by relying on cached results.'
+            )
+            ->addOption(
+               'log-json',
+               null,
+               InputOption::VALUE_REQUIRED,
+               'Generate log file in JSON format.'
+            )
+            ->addOption(
+               'log-text',
+               null,
+               InputOption::VALUE_REQUIRED,
+               'Generate log file in text format.'
             )
         ;
     }


### PR DESCRIPTION
In my work-flow, each analysis tool has it's own configuration file (e.g. `phpunit.xml(.dist)`) which I use to determine what should be analysed and how. Logging can also be configured in these files (as is the case with humbug), however I prefer to use command line options.

e.g.
PHPUnit has `--log-json path/to/logfile.json`
PHP_CodeSniffer has `--report-json=path/to/logfile.json`

These command line options allow the tools to perform their analysis consistently when used by external systems, while allowing each individual's logging needs to be satisfied.

This PR adds two new command line options:
`--log-json=path/to/logfile.json` and `--log-text=path/to/logfile.txt`

Log files can still be configured in the `humbug.json(.dist)` file, however the command line options (if present) will take precedence.

Any and all feedback is welcome.