### PR TITLE
Fix phpunit listener

### DIFF
--- a/src/Adapter/Phpunit/Listeners/JsonLoggingTimeCollectorListener.php
+++ b/src/Adapter/Phpunit/Listeners/JsonLoggingTimeCollectorListener.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Humbug\Adapter\Phpunit\Listeners;
+
+use Humbug\Phpunit\Listener\TimeCollectorListener;
+use Humbug\Phpunit\Logger\JsonLogger;
+
+class JsonLoggingTimeCollectorListener extends TimeCollectorListener
+{
+    public function __construct($logFile, $rootSuiteNestingLevel = 0)
+    {
+        $logger = new JsonLogger($logFile);
+
+        parent::__construct($logger, $rootSuiteNestingLevel);
+    }
+}

--- a/src/Adapter/Phpunit/Listeners/TestSuiteFilterListener.php
+++ b/src/Adapter/Phpunit/Listeners/TestSuiteFilterListener.php
@@ -2,15 +2,23 @@
 
 namespace Humbug\Adapter\Phpunit\Listeners;
 
+use ReflectionClass;
 use Humbug\Phpunit\Listener\FilterListener;
 use Humbug\Phpunit\Filter\TestSuite\IncludeOnlyFilter;
 use Humbug\Phpunit\Filter\TestSuite\FastestFirstFilter;
 
 class TestSuiteFilterListener extends FilterListener
 {
-    public function __construct($rootSuiteNestingLevel = 0, $filterTestSuites = [], $filterStatsPath = [])
+    /**
+     * @param int $rootSuiteNestingLevel
+     * @param string $filterStatsPath path used by fastesFirstFilter
+     * @param string ...$filterTestSuites
+     */
+    public function __construct($rootSuiteNestingLevel = 0, $filterStatsPath = null)
     {
-        $includeOnlyFilter = new IncludeOnlyFilter($filterTestSuites);
+        $filterTestSuites = array_slice(func_get_args(), 2);
+        $includeOnlyFilter = $this->createIncludeOnlyFilter($filterTestSuites);
+
         $fastestFirstFilter = new FastestFirstFilter($filterStatsPath);
 
         parent::__construct(
@@ -18,5 +26,17 @@ class TestSuiteFilterListener extends FilterListener
             $includeOnlyFilter,
             $fastestFirstFilter
         );
+    }
+
+    /**
+     * Create the IncludeOnlyFilter based on an array of suites. We're using
+     * a ReflectionClass to instantiate the filter with the provided arguments.
+     */
+    private function createIncludeOnlyFilter($filterTestSuites)
+    {
+        $reflection = new ReflectionClass('Humbug\Phpunit\Filter\TestSuite\IncludeOnlyFilter');
+        $includeOnlyFilter = $reflection->newInstanceArgs($filterTestSuites);
+
+        return $includeOnlyFilter;
     }
 }

--- a/src/Adapter/Phpunit/Listeners/TestSuiteFilterListener.php
+++ b/src/Adapter/Phpunit/Listeners/TestSuiteFilterListener.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Humbug\Adapter\Phpunit\Listeners;
+
+use Humbug\Phpunit\Listener\FilterListener;
+use Humbug\Phpunit\Filter\TestSuite\IncludeOnlyFilter;
+use Humbug\Phpunit\Filter\TestSuite\FastestFirstFilter;
+
+class TestSuiteFilterListener extends FilterListener
+{
+    public function __construct($rootSuiteNestingLevel = 0, $filterTestSuites = [], $filterStatsPath = [])
+    {
+        $includeOnlyFilter = new IncludeOnlyFilter($filterTestSuites);
+        $fastestFirstFilter = new FastestFirstFilter($filterStatsPath);
+
+        parent::__construct(
+            $rootSuiteNestingLevel,
+            $includeOnlyFilter,
+            $fastestFirstFilter
+        );
+    }
+}

--- a/src/Adapter/Phpunit/XmlConfigurationBuilder.php
+++ b/src/Adapter/Phpunit/XmlConfigurationBuilder.php
@@ -109,16 +109,10 @@ class XmlConfigurationBuilder
         }
 
         if ($this->pathToTimeStats) {
-            $timeCollectionListener = new ObjectVisitor(
-                '\Humbug\Phpunit\Listener\TimeCollectorListener',
-                [
-                    new ObjectVisitor(
-                        '\Humbug\Phpunit\Logger\JsonLogger',
-                        [$this->pathToTimeStats]
-                    ),
-                    $xmlConfiguration->getRootTestSuiteNestingLevel()
-                ]
-            );
+            $timeCollectionListener = new ObjectVisitor('\Humbug\Adapter\Phpunit\Listeners\JsonLoggingTimeCollectorListener', [
+                $this->pathToTimeStats,
+                $xmlConfiguration->getRootTestSuiteNestingLevel()
+            ]);
             $xmlConfiguration->addListener($timeCollectionListener);
         }
 

--- a/src/Adapter/Phpunit/XmlConfigurationBuilder.php
+++ b/src/Adapter/Phpunit/XmlConfigurationBuilder.php
@@ -117,11 +117,10 @@ class XmlConfigurationBuilder
         }
 
         if (!empty($this->filterTestSuites) || $this->filterStatsPath) {
-            $filterListener = new ObjectVisitor('\Humbug\Adapter\Phpunit\Listeners\TestSuiteFilterListener', [
+            $filterListener = new ObjectVisitor('\Humbug\Adapter\Phpunit\Listeners\TestSuiteFilterListener', array_merge([
                 $xmlConfiguration->getRootTestSuiteNestingLevel(),
-                $this->filterTestSuites,
                 $this->filterStatsPath
-            ]);
+            ], $this->filterTestSuites));
             $xmlConfiguration->addListener($filterListener);
         }
 

--- a/src/Adapter/Phpunit/XmlConfigurationBuilder.php
+++ b/src/Adapter/Phpunit/XmlConfigurationBuilder.php
@@ -117,20 +117,11 @@ class XmlConfigurationBuilder
         }
 
         if (!empty($this->filterTestSuites) || $this->filterStatsPath) {
-            $filterListener = new ObjectVisitor(
-                '\Humbug\Phpunit\Listener\FilterListener',
-                [
-                    $xmlConfiguration->getRootTestSuiteNestingLevel(),
-                    new ObjectVisitor(
-                        '\Humbug\Phpunit\Filter\TestSuite\IncludeOnlyFilter',
-                        $this->filterTestSuites
-                    ),
-                    new ObjectVisitor(
-                        '\Humbug\Phpunit\Filter\TestSuite\FastestFirstFilter',
-                        [$this->filterStatsPath]
-                    )
-                ]
-            );
+            $filterListener = new ObjectVisitor('\Humbug\Adapter\Phpunit\Listeners\TestSuiteFilterListener', [
+                $xmlConfiguration->getRootTestSuiteNestingLevel(),
+                $this->filterTestSuites,
+                $this->filterStatsPath
+            ]);
             $xmlConfiguration->addListener($filterListener);
         }
 

--- a/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
+++ b/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
@@ -93,12 +93,9 @@ class XmlConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
         $xmlConfiguration = $this->builder->getConfiguration();
 
         $timeCollectionListener = new ObjectVisitor(
-            '\Humbug\Phpunit\Listener\TimeCollectorListener',
+            '\Humbug\Adapter\Phpunit\Listeners\JsonLoggingTimeCollectorListener',
             [
-                new ObjectVisitor(
-                    '\Humbug\Phpunit\Logger\JsonLogger',
-                    ['path/to/stats.json']
-                ),
+                'path/to/stats.json',
                 0 //root suite nesting level
             ]
         );

--- a/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
+++ b/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
@@ -115,8 +115,8 @@ class XmlConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
 
         $filterListener = new ObjectVisitor('\Humbug\Adapter\Phpunit\Listeners\TestSuiteFilterListener', [
             0, //root suite nesting level
-            $testSuites,
-            'path/to/stats.json'
+            'path/to/stats.json',
+            'suite'
         ]);
 
         $xmlConfiguration->wasCalledWith('addListener', [$filterListener]);

--- a/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
+++ b/tests/Adapter/Phpunit/XmlConfigurationBuilderTest.php
@@ -113,10 +113,10 @@ class XmlConfigurationBuilderTest extends \PHPUnit_Framework_TestCase
 
         $xmlConfiguration = $this->builder->getConfiguration();
 
-        $filterListener = new ObjectVisitor('\Humbug\Phpunit\Listener\FilterListener', [
+        $filterListener = new ObjectVisitor('\Humbug\Adapter\Phpunit\Listeners\TestSuiteFilterListener', [
             0, //root suite nesting level
-            new ObjectVisitor('\Humbug\Phpunit\Filter\TestSuite\IncludeOnlyFilter', $testSuites),
-            new ObjectVisitor('\Humbug\Phpunit\Filter\TestSuite\FastestFirstFilter', ['path/to/stats.json'])
+            $testSuites,
+            'path/to/stats.json'
         ]);
 
         $xmlConfiguration->wasCalledWith('addListener', [$filterListener]);


### PR DESCRIPTION
This PR fixes issue #158 (and its duplicate #161) by using listeners that do not have an object as its dependencies.
Note that the original bug is due to  sebastianbergmann/phpunit#1873, this PR simply circumvents the bug.

~~It should be save to merge this PR~~ however I have not yet added tests for the `TestSuiteFilterListener` and `JsonLoggingTimeCollectorListener`. I'm also not sure about the naming I've used, so any feedback is welcome.

Edit: I forgot to check Behat, I'm working on fixing the tests.