### PR TITLE
Added simple CLI interface to check humbuglog.json stats

### DIFF
--- a/bin/humbug
+++ b/bin/humbug
@@ -41,6 +41,7 @@ if ('phar:' !== substr(__FILE__, 0, 5)) {
 
 $application->add(new \Humbug\Command\Humbug());
 $application->add(new \Humbug\Command\Configure());
+$application->add(new \Humbug\Command\Stats());
 
 
 if ('phar:' === substr(__FILE__, 0, 5)) {

--- a/src/Command/Stats.php
+++ b/src/Command/Stats.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * CLI interface to parse humbuglog.json
+ *
+ * @category   Humbug
+ * @package    Humbug
+ * @copyright  Copyright (c) 2015 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    https://github.com/padraic/humbug/blob/master/LICENSE New BSD License
+ */
+
+namespace Humbug\Command;
+
+use Humbug\Log\JsonLogParser;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Stats extends Command
+{
+    const DIFF_PLUS = '+';
+    const DIFF_MINUS = '-';
+
+    /** @var InputInterface */
+    private $input;
+
+    /** @var OutputInterface */
+    private $output;
+
+    /** @var JsonLogParser */
+    private $parser;
+
+    /** @var null|string */
+    private $listPath = null;
+
+    /** @var null|string */
+    private $logPath = null;
+
+    protected function configure()
+    {
+        $this
+            ->setName('stats')
+            ->setDescription('Getting statistics from Humbug logs')
+            ->addArgument(
+                'log',
+                InputArgument::OPTIONAL,
+                'Humbug JSON log location',
+                'humbuglog.json'
+            )
+            ->addArgument(
+                'classes',
+                InputArgument::OPTIONAL,
+                'Class list path'
+            )
+            ->addOption(
+                'skip-killed',
+                null,
+                InputArgument::OPTIONAL,
+                'Skip "killed" section',
+                'no'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        $this->output = $output;
+
+        if (!$this->checkInputParameters()) {
+            return 1;
+        }
+
+        $this->initParser();
+
+        $this->processParsing();
+
+        return 0;
+    }
+
+    private function checkInputParameters()
+    {
+        $this->logPath = $this->input->getArgument('log');
+
+        if (!file_exists($this->logPath)) {
+            $this->output->writeln("<error>Error opening humbug log: {$this->listPath}</error>");
+            return false;
+        }
+        $this->listPath = $this->input->getArgument('classes');
+
+        return true;
+    }
+
+    protected function initParser()
+    {
+        $this->parser = new JsonLogParser();
+        $this->parser->setData(
+            json_decode(
+                file_get_contents($this->logPath),
+                true
+            )
+        );
+
+        if ($this->listPath) {
+            $this->parser->setClassList(
+                preg_split(
+                    '/[\n\r]+/',
+                    trim(file_get_contents($this->listPath))
+                )
+            );
+        }
+    }
+
+    protected function processParsing()
+    {
+        $verbosityLevel = $this->output->getVerbosity();
+
+        $shouldBeVerbose = $verbosityLevel > OutputInterface::VERBOSITY_QUIET;
+        $stats = $this->parser->getFilteredStats($shouldBeVerbose);
+        $sections = $this->parser->getSectionsList();
+
+        if ($this->input->getOption('skip-killed') === 'yes') {
+            unset($stats['killed']);
+            unset($sections[0]);
+        }
+
+        foreach ($sections as $section) {
+            if (!$stats['total'][$section]) {
+                continue;
+            }
+
+            $this->printSectionHeaderColor($section);
+            foreach ($stats[$section] as $class => $data) {
+                $this->printSectionData($class, $data, $verbosityLevel);
+            }
+            $this->output->writeln('');
+        }
+    }
+
+    private function printSectionHeaderColor($sectionName)
+    {
+        switch ($sectionName) {
+            case 'killed':
+                $pattern = '<fg=green>%s</fg=green>';
+                break;
+            case 'errored':
+                $pattern = '<fg=red>%s</fg=red>';
+                break;
+            case 'escaped':
+                $pattern = '<fg=yellow>%s</fg=yellow>';
+                break;
+            case 'timeouts':
+                $pattern = '<fg=cyan>%s</fg=cyan>';
+                break;
+            default:
+                $pattern = '%s';
+        }
+
+        $this->output->writeln(sprintf($pattern, str_repeat('=', 20)));
+        $this->output->writeln(' ' . sprintf($pattern, ucfirst($sectionName)));
+        $this->output->writeln(sprintf($pattern, str_repeat('=', 20)));
+    }
+
+    /**
+     * @param string $class
+     * @param array $data
+     * @param $verbosityLevel
+     */
+    protected function printSectionData($class, $data, $verbosityLevel)
+    {
+        $this->output->writeln(
+            sprintf(
+                "%-70s    <info>%d</info>",
+                $class,
+                $data['count']
+            )
+        );
+
+        if ($verbosityLevel < OutputInterface::VERBOSITY_VERBOSE || count($data['items']) <= 0) {
+            return;
+        }
+
+        foreach ($data['items'] as $item) {
+            $this->output->writeln(
+                sprintf(
+                    '    %s(): <comment>%d</comment>',
+                    $item['method'],
+                    $item['line']
+                )
+            );
+
+            if ($verbosityLevel < OutputInterface::VERBOSITY_VERY_VERBOSE) {
+                continue;
+            }
+
+            if ($verbosityLevel === OutputInterface::VERBOSITY_VERY_VERBOSE) {
+                $diff = $this->parseDiffShort($item['diff']);
+                $pad = '        ';
+            } else {
+                $diff = $this->parseDiffFull($item['diff'], $item['line']);
+                $pad = '';
+            }
+
+            $this->output->writeln($pad . $diff);
+        }
+
+        $this->output->writeln('');
+    }
+
+    private function parseDiffFull($diff, $diffLine)
+    {
+        $diff = preg_split('/[\n\r]+/', $diff);
+        $diff = array_slice($diff, 3);
+        $new = '';
+        $old = '';
+        $diffPos = -1;
+
+        foreach ($diff as $lineNum => $line) {
+            list($lineSign, $lineClean) = $this->stringSplitByIndex($line, 1);
+
+            if (!in_array($lineSign, array(static::DIFF_PLUS, static::DIFF_MINUS))) {
+                continue;
+            }
+
+            if ($line[0] === static::DIFF_PLUS) {
+                $new = $lineClean;
+            } else {
+                $old = $lineClean;
+                $diffPos = $lineNum;
+            }
+        }
+
+        $diff[$diffPos] = $this->generateDiffString($old, $new);
+        unset($diff[$diffPos + 1]);
+
+        $startLine = $diffLine - $diffPos + 3;
+        $tag = ($startLine != $diffLine) ? 'comment' : 'fg=red';
+
+        foreach ($diff as $num => $item) {
+            $diff[$num] = sprintf(
+                '<%s>%s</%s>:%s',
+                $tag,
+                $startLine,
+                $tag,
+                $item
+            );
+            $startLine++;
+        }
+
+        return implode("\n", $diff);
+    }
+
+    private function parseDiffShort($diff)
+    {
+        $diff = preg_split('/[\n\r]+/', $diff);
+        $diff = array_slice($diff, 3);
+        $new = '';
+        $old = '';
+
+        foreach ($diff as $lineNum => $line) {
+            list($lineSign, $lineClean) = $this->stringSplitByIndex($line, 1);
+
+            if (strlen($line) === 0) {
+                continue;
+            }
+
+            if (!in_array($lineSign, array(static::DIFF_PLUS, static::DIFF_MINUS))) {
+                unset($diff[$lineNum]);
+                continue;
+            }
+
+            $lineClean = trim($lineClean);
+
+            if ($line[0] === static::DIFF_PLUS) {
+                $new = $lineClean;
+            } else {
+                $old = $lineClean;
+            }
+        }
+
+        return $this->generateDiffString($old, $new);
+    }
+
+    private function generateDiffString($old, $new)
+    {
+        $fromStart = strspn($old ^ $new, "\0");
+        $fromEnd = strspn(strrev($old) ^ strrev($new), "\0");
+
+        $oldEnd = strlen($old) - $fromEnd;
+        $newEnd = strlen($new) - $fromEnd;
+
+        $start = substr($new, 0, $fromStart);
+        $end = substr($new, $newEnd);
+        $newDiff = substr($new, $fromStart, $newEnd - $fromStart);
+        $oldDiff = substr($old, $fromStart, $oldEnd - $fromStart);
+
+        $result = sprintf(
+            '%s<fg=red>%s</fg=red><fg=green>%s</fg=green>%s',
+            $start,
+            $oldDiff,
+            $newDiff,
+            $end
+        );
+
+        return $result;
+    }
+
+    /**
+     * @param $string
+     * @param $index
+     * @return array
+     */
+    private function stringSplitByIndex($string, $index)
+    {
+        return [
+            substr($string, 0, $index),
+            substr($string, $index)
+        ];
+    }
+}

--- a/src/Log/JsonLogParser.php
+++ b/src/Log/JsonLogParser.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Class collecting source and file data to track changes over time.
+ *
+ * @category   Humbug
+ * @package    Humbug
+ * @copyright  Copyright (c) 2015 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    https://github.com/padraic/humbug/blob/master/LICENSE New BSD License
+ */
+
+namespace Humbug\Log;
+
+/**
+ * Class JsonLogParser
+ * @package app\models
+ */
+class JsonLogParser
+{
+    private $data;
+    private $classesToFilter = [];
+
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+
+    public function setClassList($classList)
+    {
+        $this->classesToFilter = $classList;
+    }
+
+    public function getFilteredStats($verbose = false)
+    {
+        $result = $this->getOverallStats($verbose);
+        $sections = $this->getSectionsList();
+        $shouldFilter = count($this->classesToFilter) > 0;
+
+        foreach ($sections as $section) {
+            $count = 0;
+            foreach ($result[$section] as $key => $value) {
+                if ($shouldFilter && !in_array($key, $this->classesToFilter)) {
+                    unset ($result[$section][$key]);
+                } else {
+                    $count += $value['count'];
+                }
+            }
+            $result['total'][$section] = $count;
+        }
+        return $result;
+    }
+
+    public function getOverallStats($verbose = true)
+    {
+        $result = array_combine($this->getSectionsList(), [[], [], [], []]);
+
+        $sections = $this->getSectionsList();
+        foreach ($sections as $section) {
+            if (isset($this->data[$section]) && is_array($this->data[$section])) {
+                foreach ($this->data[$section] as $item) {
+                    $className = str_replace('\\\\', '\\', $item['class']);
+                    if (isset($result[$section][$className])) {
+                        $result[$section][$className]['count']++;
+                    } else {
+                        $result[$section][$className]['count'] = 1;
+                        $result[$section][$className]['classHash'] = md5($item['class'] . time());
+                    }
+                    if ($verbose) {
+                        $result[$section][$className]['items'][] = [
+                            'method' => $item['method'],
+                            'line' => $item['line'],
+                            'tests' => $item['tests'],
+                            'mutator' => $item['mutator'],
+                            'diff' => $item['diff'],
+                            'diffProcessed' => $this->processDiff($item['diff']),
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function getSectionsList()
+    {
+        return ["killed", "escaped", "errored", "timeouts"];
+    }
+
+    public function getSummary()
+    {
+        return isset($this->data['summary']) ? $this->data['summary'] : [];
+    }
+
+    public function generateListSummary($list)
+    {
+        $this->setClassList($list);
+        $rawData = $this->getFilteredStats(true);
+        $stats = [];
+        $total = 0;
+        foreach ($rawData as $section => $items) {
+            $stats[$section . '_classes'] = count($items);
+            $stats[$section] = 0;
+            if (count($items)) {
+                foreach ($items as $item) {
+                    $stats[$section] += $item['count'];
+                    $total += $item['count'];
+                }
+            }
+        }
+        $stats['total'] = $total;
+        $percent = [];
+        foreach ($stats as $section => $amount) {
+            $percents[$section] = round((float)$amount / (float)$stats['total'] * 100);
+        }
+        $percents['killed'] = 100 - $percents['escaped'] - $percents['errored'] - $percents['timeouts'];
+
+        return [
+            'amounts' => $stats,
+            'percents' => $percents
+        ];
+    }
+
+    private function processDiff($diff)
+    {
+        $diff = preg_split('/[\n\r]+/', $diff);
+        unset($diff[0]);
+        unset($diff[1]);
+        unset($diff[2]);
+
+        $lineNumNew = null;
+        $lineNumOld = null;
+
+        foreach ($diff as $lineNum => $line) {
+            if (!in_array(substr($line, 0, 1), ['+', '-'])) {
+                continue;
+            }
+
+            $firstSymbol = substr($line, 0, 1);
+            if ($firstSymbol === '+') {
+                $lineNumNew = $lineNum;
+            } else {
+                $lineNumOld = $lineNum;
+            }
+        }
+
+        if ($lineNumOld !== null) {
+            $diff[$lineNumOld] = $this->generateDiffString($diff[$lineNumOld], $diff[$lineNumNew]);
+        }
+        if ($lineNumNew !== null) {
+            $diff[$lineNumNew] = $this->generateDiffString($diff[$lineNumOld], $diff[$lineNumNew], false);
+        }
+
+        return $diff;
+    }
+
+    private function generateDiffString($old, $new, $isOld = true)
+    {
+        $old = substr($old, 1);
+        $new = substr($new, 1);
+        $fromStart = strspn($old ^ $new, "\0");
+        $fromEnd = strspn(strrev($old) ^ strrev($new), "\0");
+
+        $oldEnd = strlen($old) - $fromEnd;
+        $newEnd = strlen($new) - $fromEnd;
+
+        $start = substr($new, 0, $fromStart);
+        $end = substr($new, $newEnd);
+        $newDiff = substr($new, $fromStart, $newEnd - $fromStart);
+        $oldDiff = substr($old, $fromStart, $oldEnd - $fromStart);
+
+        if ($isOld) {
+            return '-' . $start . '%start%' . $oldDiff . '%end%' . $end;
+        }
+
+        return '+' . $start . '%start%' . $newDiff . '%end%' . $end;
+    }
+}

--- a/src/Log/JsonLogParser.php
+++ b/src/Log/JsonLogParser.php
@@ -39,7 +39,7 @@ class JsonLogParser
             $count = 0;
             foreach ($result[$section] as $key => $value) {
                 if ($shouldFilter && !in_array($key, $this->classesToFilter)) {
-                    unset ($result[$section][$key]);
+                    unset($result[$section][$key]);
                 } else {
                     $count += $value['count'];
                 }


### PR DESCRIPTION
I've used this code in my projects and think it can be useful in humbug itself.
New command added, so you can call:
> bin/humbug stats ../my-project/humbuglog.json ../my-project/list-of-classes.txt --skip-killed=yes [-vvv]

and get stats parsed from humbuglog.json

CLI reference:
  humbug stats [humbuglog.json location] [class list location] [--skip-killed=yes] [-vvv]
* humbuglog.json location,  defaults to ./humbuglog.json
* class list location is a path of text file, containing full class names, one per line. 

  only this files-related stats would be shown
* --skip-killed=yes is used to completely skip output of "killed" section
* various verbosity levels define amount of info to be displayed:
  * by default, there's one line per class with amount of mutants killed/escaped/errored/timed out (depending on output section)
  * -v adds one line per each mutant with line number and method name
  * -vv adds extra line for each mutant, displaying diff view of line mutant is detected in
  * -vvv shows full diff with several lines before and after

This can be tested on humbug itself, by running in humbug's dir:
> bin/humbug
> bin/humbug stats [-vvv]