### PR TITLE
Wrong error message when composer.phar do not exists on custom config path.

### DIFF
--- a/src/Adapter/Phpunit.php
+++ b/src/Adapter/Phpunit.php
@@ -97,7 +97,7 @@ class Phpunit extends AdapterAbstract
         /**
          * Initial command is expected, of course.
          */
-        $phpunitFinder = new PhpunitExecutableFinder;
+        $phpunitFinder = new PhpunitExecutableFinder(getcwd());
         $command = $phpunitFinder->find();
         array_unshift($jobopts['command'], $command);
 
@@ -120,7 +120,7 @@ class Phpunit extends AdapterAbstract
             $container->getBootstrap(),
             $interceptFile
         );
-        
+
         $process = new Process(implode(' ', $jobopts['command']), $jobopts['testdir'], array_replace($_ENV, $_SERVER));
         $process->setTimeout($timeout);
 

--- a/src/Process/ComposerExecutableFinder.php
+++ b/src/Process/ComposerExecutableFinder.php
@@ -15,6 +15,18 @@ use Symfony\Component\Process\ExecutableFinder;
 
 class ComposerExecutableFinder extends AbstractExecutableFinder
 {
+    /**
+     * @var string
+     */
+    private $basePath;
+
+    /**
+     * @param string $basePath
+     */
+    public function __construct($basePath)
+    {
+        $this->basePath = $basePath;
+    }
 
     /**
      * @return string
@@ -25,13 +37,19 @@ class ComposerExecutableFinder extends AbstractExecutableFinder
     }
 
     /**
+     * @throws \Humbug\Exception\RuntimeException
      * @return string
      */
     private function tryAndGetNiceThing()
     {
         $probable = ['composer', 'composer.phar'];
         $finder = new ExecutableFinder;
-        $immediatePaths = [getcwd(), realpath(getcwd().'/../'), realpath(getcwd().'/../../')];
+        $immediatePaths = [
+            $this->basePath,
+            realpath($this->basePath . '/../'),
+            realpath($this->basePath . '/../../')
+        ];
+
         foreach ($probable as $name) {
             if ($path = $finder->find($name, null, $immediatePaths)) {
                 return $path;

--- a/tests/Adapter/Phpunit/Process/PhpunitExecutableFinderTest.php
+++ b/tests/Adapter/Phpunit/Process/PhpunitExecutableFinderTest.php
@@ -11,14 +11,26 @@
 namespace Humbug\Test\Adapter\Phpunit\Process;
 
 use Humbug\Adapter\Phpunit\Process\PhpunitExecutableFinder;
+use org\bovigo\vfs\vfsStream;
 
 class PhpunitExecutableFinderTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testFinderCanLocatePhpunitExecutable()
     {
-        $finder = new PhpunitExecutableFinder();
+        $finder = new PhpunitExecutableFinder(getcwd());
         $result = $finder->find();
         $this->assertRegExp('%phpunit(\\.bat|\\.phar)?$%', $result);
+    }
+
+    /**
+     * @expectedException        \Humbug\Exception\RuntimeException
+     * @expectedExceptionMessage Unable to locate a Composer executable on local system.
+     */
+    public function testFinderCannotLocateComposerShouldThrowException()
+    {
+        $root = vfsStream::setup('root', null, []);
+        $finder = new PhpunitExecutableFinder($root->path());
+        $finder->find();
     }
 }

--- a/tests/Process/ComposerExecutableFinderTest.php
+++ b/tests/Process/ComposerExecutableFinderTest.php
@@ -11,14 +11,26 @@
 namespace Humbug\Test\Process;
 
 use Humbug\Process\ComposerExecutableFinder;
+use org\bovigo\vfs\vfsStream;
 
 class ComposerExecutableFinderTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testFinderCanLocatePhpunitExecutable()
     {
-        $finder = new ComposerExecutableFinder();
+        $finder = new ComposerExecutableFinder(getcwd());
         $result = $finder->find();
         $this->assertRegExp('%composer(\\.bat|\\.phar)?$%', $result);
+    }
+
+    /**
+     * @expectedException        \Humbug\Exception\RuntimeException
+     * @expectedExceptionMessage Unable to locate a Composer executable on local system.
+     */
+    public function testFinderCannotLocateComposerExecutableShouldThrowException()
+    {
+        $root = vfsStream::setup('root');
+        $finder = new ComposerExecutableFinder($root->path());
+        $finder->find();
     }
 }


### PR DESCRIPTION
This issue was caused, when the following steps are encountered:
- When the `composer.phar` do not exists at the root
- `composer.json` file defines a different path to the `bin`

`composer.json` ie. 

``` json
    "require-dev": {
        "humbug/humbug": "~1.0@dev"
    },
    "config": {
        "bin-dir": "bin/"
    }
```

When this happens, and you run humbug, we get the following error: 

```
[Humbug\Exception\RuntimeException]                                                    
  Unable to locate a PHPUnit executable on local system. Ensure that PHPUnit is installed and available.
```

Putting the composer finder outside the try catch, now show the right errors about the composer missing.
